### PR TITLE
[KIM-116] 게시글 조회 기능 구현

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -3,6 +3,7 @@ package com.devcourse.be04daangnmarket.post.api;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -30,6 +31,13 @@ public class PostRestController {
 			, request.price(), request.views(), request.transactionType(), request.category(), request.status());
 
 		return new ResponseEntity<>(response, HttpStatus.CREATED);
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<PostResponse> getPost(@PathVariable Long id) {
+		PostResponse response = postService.getPost(id);
+
+		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
 	@PutMapping("/{id}")

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -1,5 +1,8 @@
 package com.devcourse.be04daangnmarket.post.api;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -9,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.devcourse.be04daangnmarket.post.application.PostService;
@@ -38,6 +42,15 @@ public class PostRestController {
 		PostResponse response = postService.getPost(id);
 
 		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@GetMapping
+	public ResponseEntity<Page<PostResponse>> getAllPost(@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "0") int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<PostResponse> responses = postService.getAllPost(pageable);
+
+		return new ResponseEntity<>(responses, HttpStatus.OK);
 	}
 
 	@PutMapping("/{id}")

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -43,6 +43,12 @@ public class PostService {
 		return toResponse(post);
 	}
 
+	public PostResponse getPost(Long id) {
+		Post post = findPostById(id);
+
+		return toResponse(post);
+	}
+
 	@Transactional
 	public PostResponse update(Long id, String title, String description, int price, int views,
 		TransactionType transactionType, Category category, Status status) {

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -4,6 +4,8 @@ import static com.devcourse.be04daangnmarket.post.exception.ErrorMessage.*;
 
 import java.util.NoSuchElementException;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +49,11 @@ public class PostService {
 		Post post = findPostById(id);
 
 		return toResponse(post);
+	}
+
+	public Page<PostResponse> getAllPost(Pageable pageable) {
+		return postRepository.findAll(pageable)
+			.map(this::toResponse);
 	}
 
 	@Transactional

--- a/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
@@ -9,9 +9,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
 
 @Entity
 @DynamicInsert
+@Table(name = "posts")
 public class Post extends BaseEntity {
 
 	@Column(nullable = false)

--- a/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.devcourse.be04daangnmarket.common.config.SecurityConfig;
+import com.devcourse.be04daangnmarket.member.application.MemberService;
 import com.devcourse.be04daangnmarket.post.application.PostService;
 import com.devcourse.be04daangnmarket.post.domain.Category;
 import com.devcourse.be04daangnmarket.post.domain.Status;
@@ -37,6 +38,9 @@ class PostRestControllerTest {
 	@MockBean
 	private PostService postService;
 
+	@MockBean
+	MemberService memberService;
+
 	@Test
 	@DisplayName("게시글 등록 REST API 성공")
 	void PostRestControllerTest() throws Exception {
@@ -54,7 +58,7 @@ class PostRestControllerTest {
 		mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/posts")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(status().isOk())
+			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.title").value(request.title()))
 			.andExpect(jsonPath("$.description").value(request.description()))
 			.andExpect(jsonPath("$.price").value(request.price()))
@@ -62,6 +66,30 @@ class PostRestControllerTest {
 			.andExpect(jsonPath("$.transactionType").value(request.transactionType().toString()))
 			.andExpect(jsonPath("$.category").value(request.category().toString()))
 			.andExpect(jsonPath("$.status").value(request.status().toString()));
+
+	}
+
+	@Test
+	@DisplayName("게시글 단일 상세 조회 REST API 성공")
+	public void getPostTest() throws Exception {
+		// Given
+		Long postId = 1L;
+		PostResponse mockResponse = new PostResponse(1L, "Keyboard", "nice Keyboard", 100, 1000,
+			TransactionType.SALE, Category.DIGITAL_DEVICES, Status.FOR_SALE);
+
+		when(postService.getPost(1L)).thenReturn(mockResponse);
+
+		// When and Then
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/posts/" + postId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.title").value("Keyboard"))
+			.andExpect(jsonPath("$.description").value("nice Keyboard"))
+			.andExpect(jsonPath("$.price").value(100))
+			.andExpect(jsonPath("$.views").value(1000))
+			.andExpect(jsonPath("$.transactionType").value(TransactionType.SALE.toString()))
+			.andExpect(jsonPath("$.category").value(Category.DIGITAL_DEVICES.toString()))
+			.andExpect(jsonPath("$.status").value(Status.FOR_SALE.toString()));
+
 	}
 
 	@Test
@@ -75,7 +103,7 @@ class PostRestControllerTest {
 		PostResponse mockResponse = new PostResponse(1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE, Category.DIGITAL_DEVICES, Status.FOR_SALE);
 
-		when(postService.update(1L,"Keyboard", "nice Keyboard", 100, 1000,
+		when(postService.update(1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE, Category.DIGITAL_DEVICES, Status.FOR_SALE)).thenReturn(mockResponse);
 
 		// When-Then
@@ -91,6 +119,7 @@ class PostRestControllerTest {
 			.andExpect(jsonPath("$.transactionType").value(request.transactionType().toString()))
 			.andExpect(jsonPath("$.category").value(request.category().toString()))
 			.andExpect(jsonPath("$.status").value(request.status().toString()));
+
 	}
 
 	@Test
@@ -105,6 +134,7 @@ class PostRestControllerTest {
 			.andExpect(status().isNoContent());
 
 		verify(postService, times(1)).delete(postId);
+
 	}
 
 }

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -2,9 +2,7 @@ package com.devcourse.be04daangnmarket.post.application;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
 import java.util.Optional;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -67,9 +65,36 @@ class PostServiceTest {
 	}
 
 	@Test
+	@DisplayName("게시글 단일 상세 조회 성공")
+	void getPostTest() {
+		// given
+		Long postId = 1L;
+
+		Post post = Post.builder()
+			.title("keyboard~!")
+			.description("this keyboard is good")
+			.price(100000)
+			.views(1000)
+			.transactionType(TransactionType.SALE)
+			.category(Category.DIGITAL_DEVICES)
+			.status(Status.FOR_SALE)
+			.build();
+
+		when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+
+		// when
+		PostResponse response = postService.getPost(postId);
+
+		// then
+		assertNotNull(response);
+		assertEquals(post.getId(), response.id());
+		verify(postRepository, times(1)).findById(postId);
+	}
+
+	@Test
 	@DisplayName("게시글 수정 성공")
 	void updatePostTest() {
-		// Given
+		// given
 		Long id = 1L;
 		String title = "keyboard~!";
 		String description = "this keyboard is good";
@@ -91,11 +116,11 @@ class PostServiceTest {
 		;
 		when(postRepository.findById(id)).thenReturn(Optional.of(post));
 
-		// When
+		// when
 		PostResponse response = postService.update(id, title, description, price, views,
 			transactionType, category, status);
 
-		// Then
+		// then
 		assertNotNull(response);
 		assertEquals(title, post.getTitle());
 		assertEquals(description, post.getDescription());
@@ -111,13 +136,13 @@ class PostServiceTest {
 	@Test
 	@DisplayName("게시글 삭제 성공")
 	public void deletePostTest() {
-		// Given
+		// given
 		Long postId = 1L;
 
-		// When
+		// when
 		postService.delete(postId);
 
-		// Then
+		// then
 		verify(postRepository, times(1)).deleteById(postId);
 	}
 

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -2,12 +2,17 @@ package com.devcourse.be04daangnmarket.post.application;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import com.devcourse.be04daangnmarket.post.domain.Category;
 import com.devcourse.be04daangnmarket.post.domain.Post;
 import com.devcourse.be04daangnmarket.post.domain.Status;
@@ -51,7 +56,7 @@ class PostServiceTest {
 		// when
 		PostResponse response = postService.create(title, description, price, views, transactionType, category, status);
 
-		// Then
+		// then
 		assertNotNull(response);
 		assertEquals(title, response.title());
 		assertEquals(description, response.description());
@@ -89,6 +94,46 @@ class PostServiceTest {
 		assertNotNull(response);
 		assertEquals(post.getId(), response.id());
 		verify(postRepository, times(1)).findById(postId);
+	}
+
+	@Test
+	@DisplayName("게시글 전체 조회 성공")
+	public void testGetAllPost() {
+		// given
+		Post post = Post.builder()
+			.title("keyboard~!")
+			.description("this keyboard is good")
+			.price(100000)
+			.views(1000)
+			.transactionType(TransactionType.SALE)
+			.category(Category.DIGITAL_DEVICES)
+			.status(Status.FOR_SALE)
+			.build();
+
+		Post post2 = Post.builder()
+			.title("mouse~!")
+			.description("this mouse is good")
+			.price(100000)
+			.views(1000)
+			.transactionType(TransactionType.SALE)
+			.category(Category.DIGITAL_DEVICES)
+			.status(Status.FOR_SALE)
+			.build();
+
+		List<Post> posts = List.of(post,post2);
+
+		Pageable pageable = PageRequest.of(0, 10);
+		Page<Post> page = new PageImpl<>(posts, pageable, posts.size());
+
+		when(postRepository.findAll(pageable)).thenReturn(page);
+
+		// when
+		Page<PostResponse> resultPage = postService.getAllPost(pageable);
+
+		// then
+		assertEquals(page.getTotalElements(), resultPage.getTotalElements());
+		assertEquals(page.getNumber(), resultPage.getNumber());
+
 	}
 
 	@Test


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명
- 게시글 조회 기능 구현 및 테스트 코드를 작성했습니다.

### 🥕 작업단위
- [x] 게시글 단일 상세 조회 기능 구현
- [x] 게시글 단일 상세 조회 REST API 기능 구현
- [x] 게시글 전체 조회 기능 구현
- [x] 게시글 전체 조회 REST API 기능 구현

### 🐰 PR POINT
- 전체조회에 대해 페이징 처리를 해주었으며 페이지 크기는 10으로 해주었습니다.

### 🥕 리뷰어에게 하고싶은 말
- 컨트롤러 슬라이스 테스트시 서비스를 다 @MockBean으로 해줘야하는 문제가 있었습니다.
