### PR TITLE
[KIM-119] 댓글 조회 기능 구현

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
@@ -3,6 +3,10 @@ package com.devcourse.be04daangnmarket.comment.api;
 import com.devcourse.be04daangnmarket.comment.application.CommentService;
 import com.devcourse.be04daangnmarket.comment.dto.CommentResponse;
 import com.devcourse.be04daangnmarket.comment.dto.CreateCommentRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,8 +42,22 @@ public class CommentRestController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<CommentResponse> getOneComment(@PathVariable("id") Long id) {
-        CommentResponse response = commentService.getOneComment(id);
+    public ResponseEntity<CommentResponse> getDetail(@PathVariable("id") Long id) {
+        CommentResponse response = commentService.getDetail(id);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<CommentResponse>> getPage(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size,
+                                                         @RequestParam(defaultValue = "createdAt.desc") String order) {
+        String[] sorted = order.split("\\.");
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sorted[0]).descending());
+        if (sorted[1].equals("asc")) {
+            pageable = PageRequest.of(page, size, Sort.by(sorted[0]).ascending());
+        }
+
+        Page<CommentResponse> response = commentService.getPage(pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
@@ -6,6 +6,7 @@ import com.devcourse.be04daangnmarket.comment.dto.CreateCommentRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,5 +34,12 @@ public class CommentRestController {
         commentService.delete(id);
 
         return new ResponseEntity(HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CommentResponse> getOneComment(@PathVariable("id") Long id) {
+        CommentResponse response = commentService.getOneComment(id);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
@@ -7,6 +7,8 @@ import com.devcourse.be04daangnmarket.comment.exception.ExceptionMessage;
 import com.devcourse.be04daangnmarket.comment.exception.NotFoundException;
 import com.devcourse.be04daangnmarket.comment.repository.CommentRepository;
 import com.devcourse.be04daangnmarket.comment.util.CommentConverter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,9 +40,14 @@ public class CommentService {
                 .orElseThrow(() -> new NotFoundException(ExceptionMessage.NOT_FOUND_COMMENT.getMessage()));
     }
 
-    public CommentResponse getOneComment(Long id) {
+    public CommentResponse getDetail(Long id) {
         Comment comment = getOne(id);
 
         return CommentConverter.toResponse(comment);
+    }
+
+    public Page<CommentResponse> getPage(Pageable pageable) {
+        return commentRepository.findAll(pageable)
+                .map(CommentConverter::toResponse);
     }
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
@@ -37,4 +37,10 @@ public class CommentService {
         return commentRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ExceptionMessage.NOT_FOUND_COMMENT.getMessage()));
     }
+
+    public CommentResponse getOneComment(Long id) {
+        Comment comment = getOne(id);
+
+        return CommentConverter.toResponse(comment);
+    }
 }

--- a/src/test/java/com/devcourse/be04daangnmarket/comment/api/CommentRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/comment/api/CommentRestControllerTest.java
@@ -10,9 +10,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -45,8 +50,8 @@ class CommentRestControllerTest {
 
         //when & then
         this.mockMvc.perform(post("/api/v1/comments")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andDo(print());
     }
@@ -58,7 +63,7 @@ class CommentRestControllerTest {
 
         //when & then
         mockMvc.perform(delete("/api/v1/comments/" + commentId)
-                .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -73,7 +78,27 @@ class CommentRestControllerTest {
 
         //when & then
         mockMvc.perform(get("/api/v1/comments/{id}", commentId)
-                .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    void 페이징_조회_성공() throws Exception {
+        //given
+        CommentResponse response1 = new CommentResponse("댓글");
+        CommentResponse response2 = new CommentResponse("댓글");
+
+        Pageable pageable = PageRequest.of(0, 10);
+        PageImpl<CommentResponse> responses = new PageImpl<>(List.of(response1, response2), pageable, 2);
+        given(commentService.getPage(pageable))
+                .willReturn(responses);
+
+        mockMvc.perform(get("/api/v1/comments")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("order", "createdAt.desc")
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
     }

--- a/src/test/java/com/devcourse/be04daangnmarket/comment/api/CommentRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/comment/api/CommentRestControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -57,6 +58,21 @@ class CommentRestControllerTest {
 
         //when & then
         mockMvc.perform(delete("/api/v1/comments/" + commentId)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    void 조회_성공() throws Exception {
+        //given
+        Long commentId = 1L;
+        CommentResponse response = new CommentResponse("댓글");
+        given(commentService.getDetail(commentId))
+                .willReturn(response);
+
+        //when & then
+        mockMvc.perform(get("/api/v1/comments/{id}", commentId)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());

--- a/src/test/java/com/devcourse/be04daangnmarket/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/comment/application/CommentServiceTest.java
@@ -2,6 +2,7 @@ package com.devcourse.be04daangnmarket.comment.application;
 
 import com.devcourse.be04daangnmarket.comment.domain.Comment;
 import com.devcourse.be04daangnmarket.comment.domain.DeletedStatus;
+import com.devcourse.be04daangnmarket.comment.dto.CommentResponse;
 import com.devcourse.be04daangnmarket.comment.exception.NotFoundException;
 import com.devcourse.be04daangnmarket.comment.repository.CommentRepository;
 import org.junit.jupiter.api.Test;
@@ -9,13 +10,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.devcourse.be04daangnmarket.comment.exception.ExceptionMessage.NOT_FOUND_COMMENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
@@ -41,13 +49,30 @@ class CommentServiceTest {
     void 삭제시_삭제상태변경_확인() {
         //given
         Comment comment = new Comment("댓글");
+        given(commentRepository.findById(comment.getId())).willReturn(Optional.of(comment));
 
         //when
-        given(commentRepository.findById(comment.getId())).willReturn(Optional.of(comment));
         commentService.delete(comment.getId());
 
         // then
         assertThat(comment.getDeletedStatus()).isEqualTo(DeletedStatus.DELETED);
+    }
 
+    @Test
+    void 페이징_조회_성공_테스트() {
+        //given
+        Comment comment1 = new Comment("댓글");
+        Comment comment2 = new Comment("댓글");
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Comment> comments = new PageImpl<>(List.of(comment1, comment2), pageable, 2);
+
+        //when
+        when(commentRepository.findAll(pageable)).thenReturn(comments);
+        Page<CommentResponse> responses = commentService.getPage(pageable);
+
+        //then
+        assertThat(comments.getSize()).isEqualTo(responses.getSize());
+        assertThat(comments.getTotalElements()).isEqualTo(responses.getTotalElements());
     }
 }

--- a/src/test/java/com/devcourse/be04daangnmarket/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/comment/application/CommentServiceTest.java
@@ -38,7 +38,7 @@ class CommentServiceTest {
     }
 
     @Test
-    void 삭제시_삭제상태변경이_확인() {
+    void 삭제시_삭제상태변경_확인() {
         //given
         Comment comment = new Comment("댓글");
 


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
댓글의 단일 조회 기능과 페이징을 통한 조회 기능을 구현하였습니다.
페이징 조회 기능에서 디폴트로 0번째 페이지, 10개의 댓글 수, 생성시간 내림차순으로 설정합니다.

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] 댓글 단일조회 기능을 구현하다
- [x] 댓글 단일조회 테스트코드를 구현하다
- [x] 댓글 페이징 조회기능을 구현하다
- [x] 댓글 페이징 조회기능 테스트코드를 구현하다

