### PR TITLE
[KIM-83] 게시글 다중이미지 저장 조회기능 추가

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/image/Domain.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/image/Domain.java
@@ -1,0 +1,19 @@
+package com.devcourse.be04daangnmarket.image;
+
+public enum Domain {
+	POST("post"),
+	COMMENT("comment"),
+	MEMBER("member")
+	;
+
+	private final String description;
+
+	Domain(String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/image/Image.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/image/Image.java
@@ -1,0 +1,35 @@
+package com.devcourse.be04daangnmarket.image;
+
+import com.devcourse.be04daangnmarket.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = " images")
+public class Image extends BaseEntity {
+
+	@Column(length = 500, nullable = false)
+	private String imageName;
+
+	@Column(length = 1000, nullable = false)
+	private String imagePath;
+
+	public Image() {
+	}
+
+	public Image(String imageName, String imagePath) {
+		this.imageName = imageName;
+		this.imagePath = imagePath;
+	}
+
+	public String getImageName() {
+		return imageName;
+	}
+
+	public String getImagePath() {
+		return imagePath;
+	}
+
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/image/Image.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/image/Image.java
@@ -11,25 +11,25 @@ import jakarta.persistence.Table;
 public class Image extends BaseEntity {
 
 	@Column(length = 500, nullable = false)
-	private String imageName;
+	private String name;
 
 	@Column(length = 1000, nullable = false)
-	private String imagePath;
+	private String path;
 
-	public Image() {
+	protected Image() {
 	}
 
-	public Image(String imageName, String imagePath) {
-		this.imageName = imageName;
-		this.imagePath = imagePath;
+	public Image(String name, String path) {
+		this.name = name;
+		this.path = path;
 	}
 
-	public String getImageName() {
-		return imageName;
+	public String getName() {
+		return name;
 	}
 
-	public String getImagePath() {
-		return imagePath;
+	public String getPath() {
+		return path;
 	}
 
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/image/ImageCreator.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/image/ImageCreator.java
@@ -1,0 +1,57 @@
+package com.devcourse.be04daangnmarket.image;
+
+import static com.devcourse.be04daangnmarket.post.exception.ErrorMessage.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class ImageCreator {
+
+	@Value("${custom.base-path.image}")
+	private String BASE_PATH;
+
+	private static final String UPLOAD_DIRECTORY = "image/";
+
+	public List<Image> createImages(List<MultipartFile> files, Domain domain) throws IOException {
+		List<Image> images = new ArrayList<>();
+
+		for (MultipartFile file : files)
+			images.add(createImage(file, domain));
+
+		return images;
+	}
+
+	public Image createImage(MultipartFile file, Domain domain) throws IOException {
+		if (file.isEmpty())
+			return null;
+
+		String URL_PATH = UPLOAD_DIRECTORY + domain.getDescription();
+		String filePath = BASE_PATH + URL_PATH;
+
+		String fileName = UUID.randomUUID() + StringUtils.cleanPath(file.getOriginalFilename());
+
+		try {
+			File directory = new File(filePath);
+			if (!directory.exists()) {
+				directory.mkdirs();
+			}
+
+			File imageFile = new File(directory, fileName);
+			file.transferTo(imageFile);
+		} catch (IOException e) {
+			throw new IOException(FILE_SAVE_ERROR.getMessage());
+		}
+
+		return new Image(file.getOriginalFilename(), URL_PATH + "/" + fileName);
+	}
+
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -1,9 +1,13 @@
 package com.devcourse.be04daangnmarket.post.api;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,7 +17,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.devcourse.be04daangnmarket.post.application.PostService;
 import com.devcourse.be04daangnmarket.post.dto.PostDto;
@@ -29,9 +35,11 @@ public class PostRestController {
 	private final PostService postService;
 
 	@PostMapping
-	public ResponseEntity<PostDto.Response> createPost(@RequestBody PostDto.CreateRequest request) {
+	public ResponseEntity<PostDto.Response> createPost(@RequestPart(name="request") PostDto.CreateRequest request
+		,@RequestPart(name = "images") List<MultipartFile> receivedImages) throws IOException {
+
 		PostDto.Response response = postService.create(request.title(), request.description()
-			, request.price(), request.transactionType(), request.category());
+			, request.price(), request.transactionType(), request.category(),receivedImages);
 
 		return new ResponseEntity<>(response, HttpStatus.CREATED);
 	}

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,11 +34,11 @@ public class PostRestController {
 	private final PostService postService;
 
 	@PostMapping
-	public ResponseEntity<PostDto.Response> createPost(@RequestPart(name="request") PostDto.CreateRequest request
-		,@RequestPart(name = "images") List<MultipartFile> receivedImages) throws IOException {
+	public ResponseEntity<PostDto.Response> createPost(@RequestPart(name = "request") PostDto.CreateRequest request
+		, @RequestPart(name = "images") List<MultipartFile> receivedImages) throws IOException {
 
 		PostDto.Response response = postService.create(request.title(), request.description()
-			, request.price(), request.transactionType(), request.category(),receivedImages);
+			, request.price(), request.transactionType(), request.category(), receivedImages);
 
 		return new ResponseEntity<>(response, HttpStatus.CREATED);
 	}

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -89,7 +89,7 @@ public class PostService {
 
 		List<String> urls =  new ArrayList<>();;
 		for(Image image : post.getImages()){
-			urls.add(image.getImagePath());
+			urls.add(image.getPath());
 		}
 
 		return new PostDto.Response(

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -86,6 +86,12 @@ public class PostService {
 	}
 
 	private PostDto.Response toResponse(Post post) {
+
+		List<String> urls =  new ArrayList<>();;
+		for(Image image : post.getImages()){
+			urls.add(image.getImagePath());
+		}
+
 		return new PostDto.Response(
 			post.getId(),
 			post.getTitle(),
@@ -94,7 +100,8 @@ public class PostService {
 			post.getViews(),
 			post.getTransactionType().getDescription(),
 			post.getCategory().getDescription(),
-			post.getStatus().getDescription()
+			post.getStatus().getDescription(),
+			urls
 		);
 	}
 

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -30,9 +30,9 @@ public class PostService {
 	private final PostRepository postRepository;
 
 	@Value("${custom.absolute-path.image}")
-	private String absolutePath;
+	private String ABSOLUTE_PATH;
 
-	private String urlPath = "image/board";
+	private static final String URL_PATH = "image/board";
 
 	public PostService(PostRepository postRepository) {
 		this.postRepository = postRepository;
@@ -112,7 +112,7 @@ public class PostService {
 		}
 
 		String fileName = StringUtils.cleanPath(image.getOriginalFilename());
-		String filePath = absolutePath + urlPath;
+		String filePath = ABSOLUTE_PATH + URL_PATH;
 
 		try {
 			File directory = new File(filePath);
@@ -126,7 +126,7 @@ public class PostService {
 			throw new IOException(FILE_SAVE_ERROR.getMessage());
 		}
 
-		return new Image(image.getOriginalFilename(), urlPath + "/" + fileName);
+		return new Image(image.getOriginalFilename(), URL_PATH + "/" + fileName);
 	}
 
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
@@ -1,17 +1,22 @@
 package com.devcourse.be04daangnmarket.post.domain;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 import com.devcourse.be04daangnmarket.common.entity.BaseEntity;
+import com.devcourse.be04daangnmarket.image.Image;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 @Entity
@@ -46,6 +51,10 @@ public class Post extends BaseEntity {
 	@ColumnDefault("'FOR_SALE'")
 	private Status status;
 
+	@OneToMany(cascade = CascadeType.ALL)
+	@JoinColumn(name = "posts_id")
+	private List<Image> images;
+
 	@Column(columnDefinition = "TIMESTAMP")
 	private LocalDateTime pullUpAt;
 
@@ -66,13 +75,14 @@ public class Post extends BaseEntity {
 	}
 
 	public Post(String title, String description, int price, TransactionType transactionType,
-		Category category) {
+		Category category, List<Image> images) {
 		this.title = title;
 		this.description = description;
 		this.price = price;
 		this.views = 0;
 		this.transactionType = transactionType;
 		this.category = category;
+		this.images = images;
 		this.status = Status.FOR_SALE;
 		this.pullUpAt = LocalDateTime.now();
 	}

--- a/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
@@ -115,6 +115,10 @@ public class Post extends BaseEntity {
 		return status;
 	}
 
+	public List<Image> getImages() {
+		return images;
+	}
+
 	public LocalDateTime getPullUpAt() {
 		return pullUpAt;
 	}

--- a/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
@@ -1,5 +1,7 @@
 package com.devcourse.be04daangnmarket.post.dto;
 
+import java.util.List;
+
 import com.devcourse.be04daangnmarket.post.domain.Category;
 import com.devcourse.be04daangnmarket.post.domain.Status;
 import com.devcourse.be04daangnmarket.post.domain.TransactionType;
@@ -32,7 +34,8 @@ public class PostDto {
 		int views,
 		String transactionType,
 		String category,
-		String status
+		String status,
+		List<String> url
 	) {
 	}
 

--- a/src/main/java/com/devcourse/be04daangnmarket/post/exception/ErrorMessage.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/exception/ErrorMessage.java
@@ -1,7 +1,10 @@
 package com.devcourse.be04daangnmarket.post.exception;
 
 public enum ErrorMessage {
-	NOT_FOUND_POST("존재하지 않는 게시물 입니다.");
+
+	NOT_FOUND_POST("존재하지 않는 게시물 입니다."),
+	FILE_SAVE_ERROR("파일을 저장할 수 없습니다.")
+	;
 
 	private final String message;
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,8 +10,13 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: create
+      generate-ddl: true
 
 jasypt:
   encryptor:
     bean: jasyptStringEncryptor
     password: ${JASYPT_KEY:testKey}
+
+custom:
+  absolute-path:
+    image: /Users/juwoongkim/Documents/clone/BE-04-Daangn-Market/src/main/resources/static/

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,5 +18,5 @@ jasypt:
     password: ${JASYPT_KEY:testKey}
 
 custom:
-  absolute-path:
+  base-path:
     image: /Users/juwoongkim/Documents/clone/BE-04-Daangn-Market/src/main/resources/static/

--- a/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
@@ -65,7 +65,7 @@ class PostRestControllerTest {
 
 		PostDto.Response mockResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
-			Status.FOR_SALE.getDescription());
+			Status.FOR_SALE.getDescription(), List.of("img_path"));
 
 		when(postService.create("Keyboard", "nice Keyboard", 100,
 			TransactionType.SALE, Category.DIGITAL_DEVICES, images)).thenReturn(mockResponse);
@@ -94,7 +94,7 @@ class PostRestControllerTest {
 		Long postId = 1L;
 		PostDto.Response mockResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
-			Status.FOR_SALE.getDescription());
+			Status.FOR_SALE.getDescription(),List.of("img_path"));
 
 		when(postService.getPost(1L)).thenReturn(mockResponse);
 
@@ -117,11 +117,11 @@ class PostRestControllerTest {
 		// given
 		PostDto.Response postResponse1 = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
-			Status.FOR_SALE.getDescription());
+			Status.FOR_SALE.getDescription(),List.of("img_path"));
 
 		PostDto.Response postResponse2 = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
-			Status.FOR_SALE.getDescription());
+			Status.FOR_SALE.getDescription(),List.of("img_path"));
 
 		List<PostDto.Response> fakeResponses = List.of(postResponse1, postResponse2);
 
@@ -153,7 +153,7 @@ class PostRestControllerTest {
 
 		PostDto.Response mockResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
-			Status.FOR_SALE.getDescription());
+			Status.FOR_SALE.getDescription(),List.of("img_path"));
 
 		when(postService.update(1L, "Keyboard", "nice Keyboard", 100,
 			TransactionType.SALE, Category.DIGITAL_DEVICES)).thenReturn(mockResponse);

--- a/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
@@ -1,8 +1,11 @@
 package com.devcourse.be04daangnmarket.post.api;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -17,9 +20,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.devcourse.be04daangnmarket.common.config.SecurityConfig;
 import com.devcourse.be04daangnmarket.post.application.PostService;
@@ -45,22 +50,35 @@ class PostRestControllerTest {
 
 	@Test
 	@DisplayName("게시글 등록 REST API 성공")
-	void createPostTest() throws Exception {
+	public void Test() throws Exception {
 
-		PostDto.CreateRequest request = new PostDto.CreateRequest("Keyboard", "nice Keyboard", 100, TransactionType.SALE,
-			Category.DIGITAL_DEVICES);
+		PostDto.CreateRequest request = new PostDto.CreateRequest("Keyboard", "nice Keyboard",
+			100, TransactionType.SALE, Category.DIGITAL_DEVICES);
+		String requestJson = objectMapper.writeValueAsString(request);
+		MockMultipartFile jsonFile = new MockMultipartFile("request", "request",
+			"application/json", requestJson.getBytes(StandardCharsets.UTF_8));
+
+		List<MultipartFile> images = new ArrayList<>();
+		MockMultipartFile imageFile = new MockMultipartFile("images", "test-image.jpg",
+			MediaType.IMAGE_JPEG_VALUE, "test image content".getBytes());
+		images.add(imageFile);
 
 		PostDto.Response mockResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
-			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(), Status.FOR_SALE.getDescription());
+			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
+			Status.FOR_SALE.getDescription());
 
 		when(postService.create("Keyboard", "nice Keyboard", 100,
-			TransactionType.SALE, Category.DIGITAL_DEVICES)).thenReturn(mockResponse);
+			TransactionType.SALE, Category.DIGITAL_DEVICES, images)).thenReturn(mockResponse);
 
-		// when then
-		mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/posts")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request)))
+		// 요청 생성
+		mockMvc.perform(
+				multipart("/api/v1/posts")
+					.file(jsonFile)
+					.file("request", requestJson.getBytes())
+					.file(imageFile)
+			)
 			.andExpect(status().isCreated())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.title").value(request.title()))
 			.andExpect(jsonPath("$.description").value(request.description()))
 			.andExpect(jsonPath("$.price").value(request.price()))
@@ -75,7 +93,8 @@ class PostRestControllerTest {
 		// given
 		Long postId = 1L;
 		PostDto.Response mockResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
-			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(), Status.FOR_SALE.getDescription());
+			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
+			Status.FOR_SALE.getDescription());
 
 		when(postService.getPost(1L)).thenReturn(mockResponse);
 
@@ -97,10 +116,12 @@ class PostRestControllerTest {
 	public void getAllPostTest() throws Exception {
 		// given
 		PostDto.Response postResponse1 = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
-			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(), Status.FOR_SALE.getDescription());
+			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
+			Status.FOR_SALE.getDescription());
 
 		PostDto.Response postResponse2 = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
-			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(), Status.FOR_SALE.getDescription());
+			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
+			Status.FOR_SALE.getDescription());
 
 		List<PostDto.Response> fakeResponses = List.of(postResponse1, postResponse2);
 
@@ -126,11 +147,13 @@ class PostRestControllerTest {
 	public void updatePostTest() throws Exception {
 		// given
 		Long postId = 1L;
-		PostDto.UpdateRequest request = new PostDto.UpdateRequest("Keyboard", "nice Keyboard", 100, TransactionType.SALE,
+		PostDto.UpdateRequest request = new PostDto.UpdateRequest("Keyboard", "nice Keyboard", 100,
+			TransactionType.SALE,
 			Category.DIGITAL_DEVICES);
 
 		PostDto.Response mockResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
-			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(), Status.FOR_SALE.getDescription());
+			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
+			Status.FOR_SALE.getDescription());
 
 		when(postService.update(1L, "Keyboard", "nice Keyboard", 100,
 			TransactionType.SALE, Category.DIGITAL_DEVICES)).thenReturn(mockResponse);

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -69,8 +69,8 @@ class PostServiceTest {
 		assertEquals(title, response.title());
 		assertEquals(description, response.description());
 		assertEquals(price, response.price());
-		assertEquals(transactionType, response.transactionType());
-		assertEquals(category, response.category());
+		assertEquals(transactionType.getDescription(), response.transactionType());
+		assertEquals(category.getDescription(), response.category());
 
 		verify(postRepository, times(1)).save(any(Post.class));
 	}
@@ -81,8 +81,10 @@ class PostServiceTest {
 		// given
 		Long postId = 1L;
 
-		Post post = new Post("keyboard~!", "this keyboard is good", 100000, 1000, TransactionType.SALE,
-			Category.DIGITAL_DEVICES, Status.FOR_SALE, LocalDateTime.now());
+		List<Image> images = List.of(new Image("name1", "path1"));
+
+		Post post = new Post("keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+			Category.DIGITAL_DEVICES, images);
 
 		when(postRepository.findById(postId)).thenReturn(Optional.of(post));
 
@@ -99,11 +101,13 @@ class PostServiceTest {
 	@DisplayName("게시글 전체 조회 성공")
 	public void testGetAllPost() {
 		// given
-		Post post = new Post("keyboard~!", "this keyboard is good", 100000, 1000, TransactionType.SALE,
-			Category.DIGITAL_DEVICES, Status.FOR_SALE, LocalDateTime.now());
+		List<Image> images = List.of(new Image("name1", "path1"));
 
-		Post post2 = new Post("mouse~!", "this mouse is good", 100000, 1000, TransactionType.SALE,
-			Category.DIGITAL_DEVICES, Status.FOR_SALE, LocalDateTime.now());
+		Post post = new Post("keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+			Category.DIGITAL_DEVICES, images);
+
+		Post post2 = new Post("keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+			Category.DIGITAL_DEVICES, images);
 
 		List<Post> posts = List.of(post, post2);
 
@@ -134,7 +138,7 @@ class PostServiceTest {
 		List<Image> images = List.of(new Image("name1", "path1"));
 
 		Post post = new Post("keyboard~!", "this keyboard is good", 50000, TransactionType.SALE,
-			Category.DIGITAL_DEVICES,images);
+			Category.DIGITAL_DEVICES, images);
 
 		when(postRepository.findById(id)).thenReturn(Optional.of(post));
 

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -3,7 +3,9 @@ package com.devcourse.be04daangnmarket.post.application;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,7 +18,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.devcourse.be04daangnmarket.image.Image;
 import com.devcourse.be04daangnmarket.post.domain.Category;
 import com.devcourse.be04daangnmarket.post.domain.Post;
 import com.devcourse.be04daangnmarket.post.domain.Status;
@@ -35,21 +41,28 @@ class PostServiceTest {
 
 	@Test
 	@DisplayName("게시글 등록 성공")
-	void createPostTest() {
+	void createPostTest() throws IOException {
 		// given
 		String title = "keyboard~!";
 		String description = "this keyboard is good";
 		int price = 100000;
 		TransactionType transactionType = TransactionType.SALE;
 		Category category = Category.DIGITAL_DEVICES;
+		List<Image> images = List.of(new Image("name1", "path1"));
 
 		Post post = new Post("keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
-			Category.DIGITAL_DEVICES);
+			Category.DIGITAL_DEVICES, images);
 
 		when(postRepository.save(any(Post.class))).thenReturn(post);
 
+		List<MultipartFile> receivedImages = new ArrayList<>();
+		MockMultipartFile imageFile = new MockMultipartFile("images", "test-image.jpg",
+			MediaType.IMAGE_JPEG_VALUE, "test image content".getBytes());
+		receivedImages.add(imageFile);
+
 		// when
-		PostDto.Response response = postService.create(title, description, price, transactionType, category);
+		PostDto.Response response = postService.create(title, description, price, transactionType, category,
+			receivedImages);
 
 		// then
 		assertNotNull(response);
@@ -118,9 +131,10 @@ class PostServiceTest {
 		int price = 100000;
 		TransactionType transactionType = TransactionType.SALE;
 		Category category = Category.DIGITAL_DEVICES;
+		List<Image> images = List.of(new Image("name1", "path1"));
 
 		Post post = new Post("keyboard~!", "this keyboard is good", 50000, TransactionType.SALE,
-			Category.DIGITAL_DEVICES);
+			Category.DIGITAL_DEVICES,images);
 
 		when(postRepository.findById(id)).thenReturn(Optional.of(post));
 


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 기존 텍스트로만 구성된 게시물 속성에 다중이미지 기능을 추가했습니다.

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] 게시글의 다중 이미지 저장기능을 추가하다
- [x] 게시글 조회시 이미지 url을 함께 전달하다
    
### 🐰 PR POINT  <!-- PR에서 중점적으로 봐야할 부문을 작성해주세요. -->
- 이미지 도메인을 따로 만들고  게시글과  일대다 단방향 설정을 두었습니다.
- resource 파일에 이미지를 저장하도록하고 설정파일에 절대경로를 명시했습니다. 사용시 src이전에 자신의 프로젝트 경로를 추가해야 동작합니다.
- 이미지 조회는 url을 통해 불러오는 것을 고려해  response에 List<String> url 속성을 두었습니다.  
 
### 🥕 리뷰어에게 하고싶은 말  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 책임을 이미지에 두려고했는데 까다로운 부분이 많아서 우선 게시글 서비스 부분에 주요 로직을 두었습니다. 
- 추후 수정해서 이미지 로직이 도메인별로 중복되고 의존되는 상황을 막아야한다고 생각합니다.


