### PR TITLE
[KIM-100] 사용자가 작성한 게시글 전체조회 기능 구현

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/image/application/ImageService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/image/application/ImageService.java
@@ -72,7 +72,7 @@ public class ImageService {
 
 	private void saveImageToLocalStorage(MultipartFile multipartFile, String uniqueName) {
 		try {
-			java.io.File file = new java.io.File(FOLDER_PATH);
+			java.io.File file = new java.io.File(FOLDER_PATH + RELATIVE_PATH);
 
 			if (isExistFile(file)) {
 				file.mkdirs();
@@ -92,7 +92,7 @@ public class ImageService {
 	}
 
 	private String getFullPath(String uniqueName) {
-		return FOLDER_PATH + uniqueName;
+		return FOLDER_PATH + RELATIVE_PATH + uniqueName;
 	}
 
 	public List<ImageResponse> getImages(DomainName domainName, Long domainId) {
@@ -133,7 +133,7 @@ public class ImageService {
 	}
 
 	private void deleteImageToLocalStorage(String path) {
-		Path fullPath = Paths.get(path);
+		Path fullPath = Paths.get(FOLDER_PATH + path);
 
 		try {
 			Files.delete(fullPath);

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -71,13 +72,13 @@ public class PostRestController {
 	}
 
 	@PutMapping("/{id}")
-	public ResponseEntity<PostDto.Response> updatePost(@PathVariable Long id,
-	                                                   @RequestPart PostDto.UpdateRequest request,
-	                                                   @RequestPart(name = "images") List<MultipartFile> files) {
-	    PostDto.Response response = postService.update(id, request.title(), request.description()
-	            , request.price(), request.transactionType(), request.category(), files);
+	@RequestMapping(method = RequestMethod.PUT)
+	public ResponseEntity<PostDto.Response> updatePost(@PathVariable Long id, PostDto.UpdateRequest request) {
 
-	    return new ResponseEntity<>(response, HttpStatus.OK);
+		PostDto.Response response = postService.update(id, request.title(), request.description()
+			, request.price(), request.transactionType(), request.category(), request.receivedImages());
+
+		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
 	@DeleteMapping("/{id}")

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -22,34 +22,34 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.devcourse.be04daangnmarket.post.application.PostService;
 import com.devcourse.be04daangnmarket.post.domain.Category;
+import com.devcourse.be04daangnmarket.post.domain.Status;
+import com.devcourse.be04daangnmarket.post.domain.TransactionType;
 import com.devcourse.be04daangnmarket.post.dto.PostDto;
 
 @RestController
 @RequestMapping("api/v1/posts")
 public class PostRestController {
 
-    public PostRestController(PostService postService) {
-        this.postService = postService;
-    }
+	public PostRestController(PostService postService) {
+		this.postService = postService;
+	}
 
-    private final PostService postService;
+	private final PostService postService;
 
-    @PostMapping
-    public ResponseEntity<PostDto.Response> createPost(@RequestPart(name = "request") PostDto.CreateRequest request
-            , @RequestPart(name = "images") List<MultipartFile> receivedImages) throws IOException {
+	@PostMapping
+	public ResponseEntity<PostDto.Response> createPost(PostDto.CreateRequest request) throws IOException {
+		PostDto.Response response = postService.create(request.title(), request.description()
+			, request.price(), request.transactionType(), request.category(), request.receivedImages());
 
-        PostDto.Response response = postService.create(request.title(), request.description()
-                , request.price(), request.transactionType(), request.category(), receivedImages);
+		return new ResponseEntity<>(response, HttpStatus.CREATED);
+	}
 
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
-    }
+	@GetMapping("/{id}")
+	public ResponseEntity<PostDto.Response> getPost(@PathVariable Long id) {
+		PostDto.Response response = postService.getPost(id);
 
-    @GetMapping("/{id}")
-    public ResponseEntity<PostDto.Response> getPost(@PathVariable Long id) {
-        PostDto.Response response = postService.getPost(id);
-
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
 
 	@GetMapping
 	public ResponseEntity<Page<PostDto.Response>> getAllPost(@RequestParam(defaultValue = "0") int page,
@@ -57,42 +57,33 @@ public class PostRestController {
 		Pageable pageable = PageRequest.of(page, size);
 		Page<PostDto.Response> responses = postService.getAllPost(pageable);
 
-        return new ResponseEntity<>(responses, HttpStatus.OK);
-    }
-
+		return new ResponseEntity<>(responses, HttpStatus.OK);
+	}
 
 	@GetMapping("/category")
-	public ResponseEntity<Page<PostDto.Response>> getPostByCategory(@RequestParam Category category,@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "10") int size){
+	public ResponseEntity<Page<PostDto.Response>> getPostByCategory(@RequestParam Category category,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
 		Pageable pageable = PageRequest.of(page, size);
 		Page<PostDto.Response> response = postService.getPostByCategory(category, pageable);
 
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
-    // @PutMapping("/{id}")
-    // public ResponseEntity<PostDto.Response> updatePost(@PathVariable Long id,
-    //                                                    @RequestPart PostDto.UpdateRequest request,
-    //                                                    @RequestPart(name = "images") List<MultipartFile> files) {
-    //     PostDto.Response response = postService.update(id, request.title(), request.description()
-    //             , request.price(), request.transactionType(), request.category(), files);
-	//
-    //     return new ResponseEntity<>(response, HttpStatus.OK);
-    // }
-
 	@PutMapping("/{id}")
 	public ResponseEntity<PostDto.Response> updatePost(@PathVariable Long id,
-		//@RequestPart PostDto.UpdateRequest request,
-		@RequestPart(name = "images") List<MultipartFile> files
-	) {
+	                                                   @RequestPart PostDto.UpdateRequest request,
+	                                                   @RequestPart(name = "images") List<MultipartFile> files) {
+	    PostDto.Response response = postService.update(id, request.title(), request.description()
+	            , request.price(), request.transactionType(), request.category(), files);
 
-		return new ResponseEntity<>(HttpStatus.OK);
+	    return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long id) {
-        postService.delete(id);
-        return ResponseEntity.noContent().build();
-    }
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Void> deletePost(@PathVariable Long id) {
+		postService.delete(id);
+		return ResponseEntity.noContent().build();
+	}
 
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -42,7 +42,6 @@ public class PostService {
                                    TransactionType transactionType, Category category, List<MultipartFile> files) throws IOException {
         Post post = new Post(title, description, price, transactionType, category);
         postRepository.save(post);
-        System.out.println(post.getId());
         List<ImageResponse> images = imageService.uploadImages(files, DomainName.POST, post.getId());
 
         return toResponse(post, images);

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -2,7 +2,6 @@ package com.devcourse.be04daangnmarket.post.application;
 
 import static com.devcourse.be04daangnmarket.post.exception.ErrorMessage.*;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -12,6 +11,7 @@ import java.util.NoSuchElementException;
 import com.devcourse.be04daangnmarket.image.application.ImageService;
 import com.devcourse.be04daangnmarket.image.domain.DomainName;
 import com.devcourse.be04daangnmarket.image.dto.ImageResponse;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -29,91 +29,98 @@ import com.devcourse.be04daangnmarket.post.repository.PostRepository;
 @Transactional(readOnly = true)
 public class PostService {
 
-    private final PostRepository postRepository;
-    private final ImageService imageService;
+	private final PostRepository postRepository;
+	private final ImageService imageService;
 
-    public PostService(PostRepository postRepository, ImageService imageService) {
-        this.postRepository = postRepository;
-        this.imageService = imageService;
-    }
+	public PostService(PostRepository postRepository, ImageService imageService) {
+		this.postRepository = postRepository;
+		this.imageService = imageService;
+	}
 
-    @Transactional
-    public PostDto.Response create(String title, String description, int price,
-                                   TransactionType transactionType, Category category, List<MultipartFile> files) throws IOException {
-        Post post = new Post(title, description, price, transactionType, category);
-        postRepository.save(post);
-        List<ImageResponse> images = imageService.uploadImages(files, DomainName.POST, post.getId());
+	@Transactional
+	public PostDto.Response create(Long memberId, String title, String description, int price,
+		TransactionType transactionType, Category category, List<MultipartFile> files) throws IOException {
+		Post post = new Post(memberId, title, description, price, transactionType, category);
+		postRepository.save(post);
+		List<ImageResponse> images = imageService.uploadImages(files, DomainName.POST, post.getId());
 
-        return toResponse(post, images);
-    }
+		return toResponse(post, images);
+	}
 
-    public PostDto.Response getPost(Long id) {
-        Post post = findPostById(id);
-        List<ImageResponse> images = imageService.getImages(DomainName.POST, id);
+	public PostDto.Response getPost(Long id) {
+		Post post = findPostById(id);
+		List<ImageResponse> images = imageService.getImages(DomainName.POST, id);
 
-        return toResponse(post, images);
-    }
+		return toResponse(post, images);
+	}
 
-    public Page<PostDto.Response> getAllPost(Pageable pageable) {
-        List<Post> posts = postRepository.findAll();
-        List<PostDto.Response> postResponses = new ArrayList<>();
+	public Page<PostDto.Response> getAllPost(Pageable pageable) {
+		List<Post> posts = postRepository.findAll();
+		List<PostDto.Response> postResponses = new ArrayList<>();
 
-        for (Post post : posts) {
-            List<ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
-            PostDto.Response postResponse = new PostDto.Response(post.getId(), post.getTitle(), post.getDescription(), post.getPrice(), post.getViews(), post.getTransactionType().name(), post.getCategory().name(), post.getStatus().name(), images);
-            postResponses.add(postResponse);
-        }
+		for (Post post : posts) {
+			List<ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
+			PostDto.Response postResponse = new PostDto.Response(post.getId(), post.getMemberId(), post.getTitle(),
+				post.getDescription(),
+				post.getPrice(), post.getViews(), post.getTransactionType().name(), post.getCategory().name(),
+				post.getStatus().name(), images);
+			postResponses.add(postResponse);
+		}
 
-        return new PageImpl<>(postResponses, pageable, postResponses.size());
-    }
+		return new PageImpl<>(postResponses, pageable, postResponses.size());
+	}
 
-    public Page<PostDto.Response> getPostByCategory(Category category, Pageable pageable) {
-        List<Post> posts = postRepository.findByCategory(category,pageable);
-        List<PostDto.Response> postResponses = new ArrayList<>();
+	public Page<PostDto.Response> getPostByCategory(Category category, Pageable pageable) {
+		List<Post> posts = postRepository.findByCategory(category, pageable);
+		List<PostDto.Response> postResponses = new ArrayList<>();
 
-        for (Post post : posts) {
-            List<ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
-            PostDto.Response postResponse = new PostDto.Response(post.getId(), post.getTitle(), post.getDescription(), post.getPrice(), post.getViews(), post.getTransactionType().name(), post.getCategory().name(), post.getStatus().name(), images);
-            postResponses.add(postResponse);
-        }
+		for (Post post : posts) {
+			List<ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
+			PostDto.Response postResponse = new PostDto.Response(post.getId(), post.getMemberId(), post.getTitle(),
+				post.getDescription(),
+				post.getPrice(), post.getViews(), post.getTransactionType().name(), post.getCategory().name(),
+				post.getStatus().name(), images);
+			postResponses.add(postResponse);
+		}
 
-        return new PageImpl<>(postResponses, pageable, postResponses.size());
-    }
+		return new PageImpl<>(postResponses, pageable, postResponses.size());
+	}
 
-    @Transactional
-    public PostDto.Response update(Long id, String title, String description, int price,
-                                   TransactionType transactionType, Category category, List<MultipartFile> files) {
-        Post post = findPostById(id);
-        post.update(title, description, price, transactionType, category);
+	@Transactional
+	public PostDto.Response update(Long id, String title, String description, int price,
+		TransactionType transactionType, Category category, List<MultipartFile> files) {
+		Post post = findPostById(id);
+		post.update(title, description, price, transactionType, category);
 
-        imageService.deleteAllImages(DomainName.POST, id);
-        List<ImageResponse> images = imageService.uploadImages(files, DomainName.POST, id);
+		imageService.deleteAllImages(DomainName.POST, id);
+		List<ImageResponse> images = imageService.uploadImages(files, DomainName.POST, id);
 
-        return toResponse(post, images);
-    }
+		return toResponse(post, images);
+	}
 
-    private Post findPostById(Long id) {
-        return postRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException(NOT_FOUND_POST.getMessage()));
-    }
+	private Post findPostById(Long id) {
+		return postRepository.findById(id)
+			.orElseThrow(() -> new NoSuchElementException(NOT_FOUND_POST.getMessage()));
+	}
 
-    @Transactional
-    public void delete(Long id) {
-        postRepository.deleteById(id);
-        imageService.deleteAllImages(DomainName.POST, id);
-    }
+	@Transactional
+	public void delete(Long id) {
+		postRepository.deleteById(id);
+		imageService.deleteAllImages(DomainName.POST, id);
+	}
 
-    private PostDto.Response toResponse(Post post, List<ImageResponse> images) {
-        return new PostDto.Response(
-                post.getId(),
-                post.getTitle(),
-                post.getDescription(),
-                post.getPrice(),
-                post.getViews(),
-                post.getTransactionType().getDescription(),
-                post.getCategory().getDescription(),
-                post.getStatus().getDescription(),
-                images
-        );
-    }
+	private PostDto.Response toResponse(Post post, List<ImageResponse> images) {
+		return new PostDto.Response(
+			post.getId(),
+			post.getMemberId(),
+			post.getTitle(),
+			post.getDescription(),
+			post.getPrice(),
+			post.getViews(),
+			post.getTransactionType().getDescription(),
+			post.getCategory().getDescription(),
+			post.getStatus().getDescription(),
+			images
+		);
+	}
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -86,6 +86,22 @@ public class PostService {
 		return new PageImpl<>(postResponses, pageable, postResponses.size());
 	}
 
+	public Page<PostDto.Response> getPostByMemberId(Long memberId, Pageable pageable) {
+		List<Post> posts = postRepository.findByMemberId(memberId, pageable);
+		List<PostDto.Response> postResponses = new ArrayList<>();
+
+		for (Post post : posts) {
+			List<ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
+			PostDto.Response postResponse = new PostDto.Response(post.getId(), post.getMemberId(), post.getTitle(),
+				post.getDescription(),
+				post.getPrice(), post.getViews(), post.getTransactionType().name(), post.getCategory().name(),
+				post.getStatus().name(), images);
+			postResponses.add(postResponse);
+		}
+
+		return new PageImpl<>(postResponses, pageable, postResponses.size());
+	}
+
 	@Transactional
 	public PostDto.Response update(Long id, String title, String description, int price,
 		TransactionType transactionType, Category category, List<MultipartFile> files) {

--- a/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
@@ -7,7 +7,6 @@ import org.hibernate.annotations.DynamicInsert;
 
 import com.devcourse.be04daangnmarket.common.entity.BaseEntity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,6 +18,9 @@ import jakarta.persistence.Table;
 @DynamicInsert
 @Table(name = "posts")
 public class Post extends BaseEntity {
+
+	@Column(nullable = false)
+	private Long memberId;
 
 	@Column(nullable = false)
 	private String title;
@@ -53,9 +55,10 @@ public class Post extends BaseEntity {
 	protected Post() {
 	}
 
-	public Post(String title, String description, int price, int views, TransactionType transactionType,
+	public Post(Long memberId, String title, String description, int price, int views, TransactionType transactionType,
 		Category category,
 		Status status, LocalDateTime pullUpAt) {
+		this.memberId = memberId;
 		this.title = title;
 		this.description = description;
 		this.price = price;
@@ -66,8 +69,9 @@ public class Post extends BaseEntity {
 		this.pullUpAt = pullUpAt;
 	}
 
-	public Post(String title, String description, int price, TransactionType transactionType,
+	public Post(Long memberId, String title, String description, int price, TransactionType transactionType,
 		Category category) {
+		this.memberId = memberId;
 		this.title = title;
 		this.description = description;
 		this.price = price;
@@ -76,6 +80,10 @@ public class Post extends BaseEntity {
 		this.category = category;
 		this.status = Status.FOR_SALE;
 		this.pullUpAt = LocalDateTime.now();
+	}
+
+	public Long getMemberId() {
+		return memberId;
 	}
 
 	public String getTitle() {

--- a/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
@@ -6,7 +6,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.devcourse.be04daangnmarket.image.dto.ImageResponse;
 import com.devcourse.be04daangnmarket.post.domain.Category;
-import com.devcourse.be04daangnmarket.post.domain.Status;
 import com.devcourse.be04daangnmarket.post.domain.TransactionType;
 
 public class PostDto {
@@ -33,6 +32,7 @@ public class PostDto {
 
 	public record Response(
 		Long id,
+		Long memberId,
 		String title,
 		String description,
 		int price,

--- a/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
@@ -26,7 +26,8 @@ public class PostDto {
 		String description,
 		int price,
 		TransactionType transactionType,
-		Category category
+		Category category,
+		List<MultipartFile> receivedImages
 	) {
 	}
 

--- a/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
@@ -2,6 +2,8 @@ package com.devcourse.be04daangnmarket.post.dto;
 
 import java.util.List;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.devcourse.be04daangnmarket.image.dto.ImageResponse;
 import com.devcourse.be04daangnmarket.post.domain.Category;
 import com.devcourse.be04daangnmarket.post.domain.Status;
@@ -14,7 +16,8 @@ public class PostDto {
 		String description,
 		int price,
 		TransactionType transactionType,
-		Category category
+		Category category,
+		List<MultipartFile> receivedImages
 	) {
 	}
 

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepository.java
@@ -2,7 +2,6 @@ package com.devcourse.be04daangnmarket.post.repository;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,5 +12,7 @@ import com.devcourse.be04daangnmarket.post.domain.Post;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 	List<Post> findByCategory(Category category, Pageable pageable);
+
+	List<Post> findByMemberId(Long memberId, Pageable pageable);
 
 }

--- a/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
@@ -4,8 +4,6 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -24,7 +22,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.devcourse.be04daangnmarket.common.config.SecurityConfig;
 import com.devcourse.be04daangnmarket.post.application.PostService;
@@ -50,39 +47,31 @@ class PostRestControllerTest {
 	@DisplayName("게시글 등록 REST API 성공")
 	public void createPostTest() throws Exception {
 
-		PostDto.CreateRequest request = new PostDto.CreateRequest("Keyboard", "nice Keyboard",
-			100, TransactionType.SALE, Category.DIGITAL_DEVICES);
-		String requestJson = objectMapper.writeValueAsString(request);
-		MockMultipartFile jsonFile = new MockMultipartFile("request", "request",
-			"application/json", requestJson.getBytes(StandardCharsets.UTF_8));
-
-		List<MultipartFile> images = new ArrayList<>();
-		MockMultipartFile imageFile = new MockMultipartFile("images", "test-image.jpg",
-			MediaType.IMAGE_JPEG_VALUE, "test image content".getBytes());
-		images.add(imageFile);
+		// given
+		MockMultipartFile file = new MockMultipartFile(
+			"file",
+			"test-file.txt",
+			MediaType.TEXT_PLAIN_VALUE,
+			"This is a test file content".getBytes()
+		);
 
 		PostDto.Response mockResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
 			Status.FOR_SALE.getDescription(), null);
 
 		when(postService.create("Keyboard", "nice Keyboard", 100,
-			TransactionType.SALE, Category.DIGITAL_DEVICES, images)).thenReturn(mockResponse);
+			TransactionType.SALE, Category.DIGITAL_DEVICES, null)).thenReturn(mockResponse);
 
-		// 요청 생성
-		mockMvc.perform(
-				multipart("/api/v1/posts")
-					.file(jsonFile)
-					.file("request", requestJson.getBytes())
-					.file(imageFile)
-			)
-			.andExpect(status().isCreated())
-			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
-			.andExpect(jsonPath("$.title").value(request.title()))
-			.andExpect(jsonPath("$.description").value(request.description()))
-			.andExpect(jsonPath("$.price").value(request.price()))
-			.andExpect(jsonPath("$.transactionType").value(request.transactionType().getDescription()))
-			.andExpect(jsonPath("$.category").value(request.category().getDescription()));
-
+		// when then
+		mockMvc.perform(MockMvcRequestBuilders.multipart("/api/v1/posts")
+				.file(file)
+				.param("title", "Keyboard")
+				.param("description", "nice Keyboard")
+				.param("price", "100")
+				.param("transactionType", TransactionType.SALE.name())
+				.param("category", Category.DIGITAL_DEVICES.name()))
+			.andExpect(MockMvcResultMatchers.status().isCreated())
+			.andExpect(jsonPath("$.title").value("Keyboard"));
 	}
 
 	@Test

--- a/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
@@ -38,8 +38,7 @@ class PostRestControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
-	@Autowired
-	private ObjectMapper objectMapper;
+
 	@MockBean
 	private PostService postService;
 
@@ -55,11 +54,11 @@ class PostRestControllerTest {
 			"This is a test file content".getBytes()
 		);
 
-		PostDto.Response mockResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
+		PostDto.Response mockResponse = new PostDto.Response(1L, 1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
 			Status.FOR_SALE.getDescription(), null);
 
-		when(postService.create("Keyboard", "nice Keyboard", 100,
+		when(postService.create(1L, "Keyboard", "nice Keyboard", 100,
 			TransactionType.SALE, Category.DIGITAL_DEVICES, null)).thenReturn(mockResponse);
 
 		// when then
@@ -79,7 +78,7 @@ class PostRestControllerTest {
 	public void getPostTest() throws Exception {
 		// given
 		Long postId = 1L;
-		PostDto.Response mockResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
+		PostDto.Response mockResponse = new PostDto.Response(1L, 1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
 			Status.FOR_SALE.getDescription(), null);
 
@@ -102,11 +101,11 @@ class PostRestControllerTest {
 	@DisplayName("게시글 전체 조회 REST API 성공")
 	public void getAllPostTest() throws Exception {
 		// given
-		PostDto.Response postResponse1 = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
+		PostDto.Response postResponse1 = new PostDto.Response(1L, 1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
 			Status.FOR_SALE.getDescription(), null);
 
-		PostDto.Response postResponse2 = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
+		PostDto.Response postResponse2 = new PostDto.Response(1L, 1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
 			Status.FOR_SALE.getDescription(), null);
 
@@ -130,43 +129,13 @@ class PostRestControllerTest {
 	}
 
 	@Test
-	@DisplayName("게시글 수정 REST API 성공")
-	public void updatePostTest() throws Exception {
-		// given
-		Long postId = 1L;
-		PostDto.UpdateRequest request = new PostDto.UpdateRequest("Keyboard", "nice Keyboard", 100,
-			TransactionType.SALE,
-			Category.DIGITAL_DEVICES);
-
-		PostDto.Response mockResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
-			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
-			Status.FOR_SALE.getDescription(), null);
-
-		when(postService.update(1L, "Keyboard", "nice Keyboard", 100,
-			TransactionType.SALE, Category.DIGITAL_DEVICES, null)).thenReturn(mockResponse);
-
-		// when then
-		mockMvc.perform(MockMvcRequestBuilders.put("/api/v1/posts/" + postId)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.id").value(postId))
-			.andExpect(jsonPath("$.title").value(request.title()))
-			.andExpect(jsonPath("$.description").value(request.description()))
-			.andExpect(jsonPath("$.price").value(request.price()))
-			.andExpect(jsonPath("$.transactionType").value(request.transactionType().getDescription()))
-			.andExpect(jsonPath("$.category").value(request.category().getDescription()));
-
-	}
-
-	@Test
 	@DisplayName("게시글 카테고리 기반 전체 조회 REST API 성공")
 	public void testGetPostByCategory() throws Exception {
 		// given
 		Category category = Category.DIGITAL_DEVICES;
 		PageRequest pageable = PageRequest.of(0, 10);
 
-		PostDto.Response postResponse = new PostDto.Response(1L, "Keyboard", "nice Keyboard", 100, 1000,
+		PostDto.Response postResponse = new PostDto.Response(1L, 1L, "Keyboard", "nice Keyboard", 100, 1000,
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
 			Status.FOR_SALE.getDescription(), null);
 

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -147,6 +147,32 @@ class PostServiceTest {
 	}
 
 	@Test
+	@DisplayName("")
+	void PostServiceTest() {
+		// given
+		Long memberId = 1L;
+		Post post = new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+			Category.DIGITAL_DEVICES);
+
+		List<Post> posts = List.of(post);
+
+		Pageable pageable = PageRequest.of(0, 10);
+		Page<Post> page = new PageImpl<>(posts);
+
+		when(postRepository.findByMemberId(memberId, pageable)).thenReturn(posts);
+
+		// when
+		Page<PostDto.Response> responses = postService.getPostByMemberId(memberId, pageable);
+
+		// then
+		assertNotNull(responses);
+		assertEquals(page.getTotalElements(), responses.getTotalElements());
+		assertEquals(page.getNumber(), responses.getNumber());
+		verify(postRepository, times(1)).findByMemberId(memberId, pageable);
+
+	}
+
+	@Test
 	@DisplayName("게시글 수정 성공")
 	void updatePostTest() {
 		// given

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -2,10 +2,12 @@ package com.devcourse.be04daangnmarket.post.application;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -18,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
+
 import com.devcourse.be04daangnmarket.image.application.ImageService;
 import com.devcourse.be04daangnmarket.post.domain.Category;
 import com.devcourse.be04daangnmarket.post.domain.Post;
@@ -41,13 +44,14 @@ class PostServiceTest {
 	@DisplayName("게시글 등록 성공")
 	void createPostTest() throws IOException {
 		// given
+		Long memberId = 1L;
 		String title = "keyboard~!";
 		String description = "this keyboard is good";
 		int price = 100000;
 		TransactionType transactionType = TransactionType.SALE;
 		Category category = Category.DIGITAL_DEVICES;
 
-		Post post = new Post("keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+		Post post = new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
 			Category.DIGITAL_DEVICES);
 
 		when(postRepository.save(any(Post.class))).thenReturn(post);
@@ -58,7 +62,7 @@ class PostServiceTest {
 		receivedImages.add(imageFile);
 
 		// when
-		PostDto.Response response = postService.create(title, description, price, transactionType, category,
+		PostDto.Response response = postService.create(memberId, title, description, price, transactionType, category,
 			receivedImages);
 
 		// then
@@ -78,7 +82,7 @@ class PostServiceTest {
 		// given
 		Long postId = 1L;
 
-		Post post = new Post("keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+		Post post = new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
 			Category.DIGITAL_DEVICES);
 
 		when(postRepository.findById(postId)).thenReturn(Optional.of(post));
@@ -96,10 +100,10 @@ class PostServiceTest {
 	@DisplayName("게시글 전체 조회 성공")
 	public void testGetAllPost() {
 		// given
-		Post post = new Post("keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+		Post post = new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
 			Category.DIGITAL_DEVICES);
 
-		Post post2 = new Post("keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+		Post post2 = new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
 			Category.DIGITAL_DEVICES);
 
 		List<Post> posts = List.of(post, post2);
@@ -122,7 +126,7 @@ class PostServiceTest {
 	public void getPostByCategoryTest() throws Exception {
 		// given
 		Category category = Category.DIGITAL_DEVICES;
-		Post post = new Post("keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+		Post post = new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
 			Category.DIGITAL_DEVICES);
 
 		List<Post> posts = List.of(post);
@@ -153,7 +157,7 @@ class PostServiceTest {
 		TransactionType transactionType = TransactionType.SALE;
 		Category category = Category.DIGITAL_DEVICES;
 
-		Post post = new Post("keyboard~!", "this keyboard is good", 50000, TransactionType.SALE,
+		Post post = new Post(1L, "keyboard~!", "this keyboard is good", 50000, TransactionType.SALE,
 			Category.DIGITAL_DEVICES);
 
 		when(postRepository.findById(id)).thenReturn(Optional.of(post));


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 게시물에서 판매자의 다른 상품보기를 위해 사용자가 작성한 게시글 전체조회 기능을 구현했습니다.

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->

- [x] 게시글 이미지 생성 api 요청방식을 하나의 DTO로 수정
- [x] 게시글 이미지 수정 api 요청방식을 하나의 DTO로 수정
- [x] 연관관계를 위해 게시글 도메인에 멤버 아이디 참조를 반영
- [x] 사용자가 작성한 게시글 전체조회 기능을 구현
 
### 🐰 PR POINT  <!-- PR에서 중점적으로 봐야할 부문을 작성해주세요. -->
- 구현하기에 앞서 이미지를 함께 받는 요청을 논의한대로 수정했습니다.
- 도메인 분석결과 상위 4개의 게시글을 노출한 뒤 판매자 전체 상품으로 이동하면 전체를 보여줍니다. 특별한 정렬기준은 찾지 못했습니다.

### 🥕 리뷰어에게 하고싶은 말  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 게시글 업데이트에 대해 테스트 코드를 짜던중 지금 형태에서 put으로는 multipart형식의 데이터를 테스트 할 수 없었습니다. 
- [참고자료](https://blog.outsider.ne.kr/1001)  해당 방식으로 해결할 수 있습니다.
- 애플리케이션에서는 돌아감으로 우선 변경하지 않았습니다.  
