### PR TITLE
[Kim-129] 댓글, 대댓글의 생성, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
@@ -41,9 +41,16 @@ public class CommentRestController {
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity delete(@PathVariable Long id) {
-        commentService.delete(id);
+    @DeleteMapping("/{commentGroup}")
+    public ResponseEntity delete(@PathVariable int commentGroup) {
+        commentService.delete(commentGroup);
+
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/reply/{id}")
+    public ResponseEntity deleteReply(@PathVariable Long id) {
+        commentService.deleteReply(id);
 
         return new ResponseEntity(HttpStatus.OK);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
@@ -3,6 +3,7 @@ package com.devcourse.be04daangnmarket.comment.api;
 import com.devcourse.be04daangnmarket.comment.application.CommentService;
 import com.devcourse.be04daangnmarket.comment.dto.CommentResponse;
 import com.devcourse.be04daangnmarket.comment.dto.CreateCommentRequest;
+import com.devcourse.be04daangnmarket.comment.dto.CreateReplyCommentRequest;
 import com.devcourse.be04daangnmarket.common.auth.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -29,6 +30,13 @@ public class CommentRestController {
     @PostMapping
     public ResponseEntity<CommentResponse> create(CreateCommentRequest request, @AuthenticationPrincipal User user) {
         CommentResponse response = commentService.create(request, user.getId());
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @PostMapping("/reply")
+    public ResponseEntity<CommentResponse> createReply(CreateReplyCommentRequest request, @AuthenticationPrincipal User user) {
+        CommentResponse response = commentService.createReply(request, user.getId());
 
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
@@ -3,6 +3,7 @@ package com.devcourse.be04daangnmarket.comment.api;
 import com.devcourse.be04daangnmarket.comment.application.CommentService;
 import com.devcourse.be04daangnmarket.comment.dto.CommentResponse;
 import com.devcourse.be04daangnmarket.comment.dto.CreateCommentRequest;
+import com.devcourse.be04daangnmarket.common.auth.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Sort;
 import com.devcourse.be04daangnmarket.comment.dto.UpdateCommentRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,9 +27,8 @@ public class CommentRestController {
     }
 
     @PostMapping
-    public ResponseEntity<CommentResponse> create(@RequestPart(name = "request") CreateCommentRequest request,
-                                                  @RequestPart(name = "images") List<MultipartFile> files) {
-        CommentResponse response = commentService.create(request, files);
+    public ResponseEntity<CommentResponse> create(CreateCommentRequest request, @AuthenticationPrincipal User user) {
+        CommentResponse response = commentService.create(request, user.getId());
 
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
@@ -41,16 +41,9 @@ public class CommentRestController {
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    @DeleteMapping("/{commentGroup}")
-    public ResponseEntity delete(@PathVariable int commentGroup) {
-        commentService.delete(commentGroup);
-
-        return new ResponseEntity(HttpStatus.OK);
-    }
-
-    @DeleteMapping("/reply/{id}")
-    public ResponseEntity deleteReply(@PathVariable Long id) {
-        commentService.deleteReply(id);
+    @DeleteMapping("/{id}")
+    public ResponseEntity delete(@PathVariable Long id) {
+        commentService.delete(id);
 
         return new ResponseEntity(HttpStatus.OK);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
@@ -62,21 +62,24 @@ public class CommentService {
     }
 
     @Transactional
-    public void delete(int commentGroup) {
-        List<Comment> groupComments = commentRepository.findAllByCommentGroup(commentGroup);
-
-        for (Comment comment : groupComments) {
-            comment.deleteStatus();
-            imageService.deleteAllImages(DomainName.COMMENT, comment.getId());
-        }
-    }
-
-
-    @Transactional
-    public void deleteReply(Long id) {
+    public void delete(Long id) {
         Comment comment = getOne(id);
+
+        if (isGroupComment(comment)) {
+            List<Comment> sameGroupComments = commentRepository.findAllByCommentGroup(comment.getCommentGroup());
+
+            for (Comment sameGroupComment : sameGroupComments) {
+                sameGroupComment.deleteStatus();
+                imageService.deleteAllImages(DomainName.COMMENT, sameGroupComment.getId());
+            }
+        }
+
         comment.deleteStatus();
         imageService.deleteAllImages(DomainName.COMMENT, id);
+    }
+
+    private boolean isGroupComment(Comment comment) {
+        return comment.getSeq() == 0;
     }
 
     private Comment getOne(Long id) {

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
@@ -62,7 +62,18 @@ public class CommentService {
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void delete(int commentGroup) {
+        List<Comment> groupComments = commentRepository.findAllByCommentGroup(commentGroup);
+
+        for (Comment comment : groupComments) {
+            comment.deleteStatus();
+            imageService.deleteAllImages(DomainName.COMMENT, comment.getId());
+        }
+    }
+
+
+    @Transactional
+    public void deleteReply(Long id) {
         Comment comment = getOne(id);
         comment.deleteStatus();
         imageService.deleteAllImages(DomainName.COMMENT, id);

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/domain/Comment.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/domain/Comment.java
@@ -22,13 +22,31 @@ public class Comment extends BaseEntity {
     @ColumnDefault("'ALIVE'")
     private DeletedStatus deletedStatus;
 
+    @Column(nullable = false)
+    private Long memberId;//작성자 Id
+
+    @Column(nullable = false)
+    private Long postId;//댓글이 작성된 게시글 Id
+
+    private int commentGroup;//그룹 Id 댓글을 작성할 때 마다 증가
+
+    private int seq;//댓글의 순서 1번이 댓글 주인, 뒤로 대댓글
+
     protected Comment() {
 
     }
 
-    public Comment(String content) {
+    public Comment(String content) {//테스트를 막기 위한 임시
+            validateContent(content);
+            this.content = content;
+        }
+
+    public Comment(String content, Long memberId, Long postId, int seq) {
         validateContent(content);
         this.content = content;
+        this.memberId = memberId;
+        this.postId = postId;
+        this.seq = seq;
     }
 
     public String getContent() {
@@ -39,6 +57,22 @@ public class Comment extends BaseEntity {
         return deletedStatus;
     }
 
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getPostId() {
+        return postId;
+    }
+
+    public int getCommentGroup() {
+        return commentGroup;
+    }
+
+    public int getSeq() {
+        return seq;
+    }
+
     private void validateContent(String content) {
         if (isCommentWithinRange(content)) {
             throw new IllegalArgumentException(INVALID_CONTENT.getMessage());
@@ -47,6 +81,10 @@ public class Comment extends BaseEntity {
 
     private boolean isCommentWithinRange(String content) {
         return content.length() > 500;
+    }
+
+    public void addGroup(int groupNumber) {
+        this.commentGroup = groupNumber + 1;
     }
 
     public void deleteStatus() {

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/domain/Comment.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/domain/Comment.java
@@ -39,14 +39,21 @@ public class Comment extends BaseEntity {
     public Comment(String content) {//테스트를 막기 위한 임시
             validateContent(content);
             this.content = content;
-        }
+    }
 
-    public Comment(String content, Long memberId, Long postId, int seq) {
+    public Comment(String content, Long memberId, Long postId) {
         validateContent(content);
         this.content = content;
         this.memberId = memberId;
         this.postId = postId;
-        this.seq = seq;
+        this.seq = 0;
+    }
+
+    public Comment(String content, Long memberId, Long postId, int commentGroup) {
+        this.content = content;
+        this.memberId = memberId;
+        this.postId = postId;
+        this.commentGroup = commentGroup;
     }
 
     public String getContent() {
@@ -85,6 +92,10 @@ public class Comment extends BaseEntity {
 
     public void addGroup(int groupNumber) {
         this.commentGroup = groupNumber + 1;
+    }
+
+    public void addSeq(int seqNumber) {
+        this.seq = seqNumber + 1;
     }
 
     public void deleteStatus() {

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/dto/CommentResponse.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/dto/CommentResponse.java
@@ -5,7 +5,16 @@ import com.devcourse.be04daangnmarket.image.dto.ImageResponse;
 import java.util.List;
 
 public record CommentResponse(
-    String content,
+        String content,
 
-    List<ImageResponse> images
-) { }
+        Long memberId,
+
+        Long postId,
+
+        int group,
+
+        int seq,
+
+        List<ImageResponse> images
+) {
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/dto/CreateCommentRequest.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/dto/CreateCommentRequest.java
@@ -1,5 +1,13 @@
 package com.devcourse.be04daangnmarket.comment.dto;
 
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
 public record CreateCommentRequest(
-        String content
+        String content,
+
+        Long postId,
+
+        List<MultipartFile> files
 ) { }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/dto/CreateReplyCommentRequest.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/dto/CreateReplyCommentRequest.java
@@ -1,0 +1,16 @@
+package com.devcourse.be04daangnmarket.comment.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record CreateReplyCommentRequest(
+        String content,
+
+        Long postId,
+
+        int commentGroup,
+
+        List<MultipartFile> files
+) {
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/repository/CommentRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/repository/CommentRepository.java
@@ -3,11 +3,15 @@ package com.devcourse.be04daangnmarket.comment.repository;
 import com.devcourse.be04daangnmarket.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT max(c.commentGroup) FROM Comment c")
-    Optional<Integer> findPostCount();
+    Optional<Integer> findMaxCommentGroup();
+
+    @Query("SELECT max(c.seq) from Comment c where c.commentGroup=:commentGroup")
+    Optional<Integer> findMaxSeqFromCommentGroup(@Param("commentGroup") int commentGroup);
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/repository/CommentRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/repository/CommentRepository.java
@@ -2,6 +2,12 @@ package com.devcourse.be04daangnmarket.comment.repository;
 
 import com.devcourse.be04daangnmarket.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT max(c.commentGroup) FROM Comment c")
+    Optional<Integer> findPostCount();
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/repository/CommentRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/repository/CommentRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -14,4 +15,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT max(c.seq) from Comment c where c.commentGroup=:commentGroup")
     Optional<Integer> findMaxSeqFromCommentGroup(@Param("commentGroup") int commentGroup);
+
+    List<Comment> findAllByCommentGroup(int commentGroup);
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/util/CommentConverter.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/util/CommentConverter.java
@@ -1,5 +1,6 @@
 package com.devcourse.be04daangnmarket.comment.util;
 
+import com.devcourse.be04daangnmarket.comment.dto.CreateReplyCommentRequest;
 import com.devcourse.be04daangnmarket.image.dto.ImageResponse;
 import com.devcourse.be04daangnmarket.comment.domain.Comment;
 import com.devcourse.be04daangnmarket.comment.dto.CommentResponse;
@@ -9,7 +10,11 @@ import java.util.List;
 
 public class CommentConverter {
     public static Comment toEntity(CreateCommentRequest dto, Long userId) {
-        return new Comment(dto.content(), userId, dto.postId(), 0);
+        return new Comment(dto.content(), userId, dto.postId());
+    }
+
+    public static Comment toEntity(CreateReplyCommentRequest dto, Long userId) {
+        return new Comment(dto.content(), userId, dto.postId(), dto.commentGroup());
     }
 
     public static CommentResponse toResponse(Comment comment, List<ImageResponse> images) {

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/util/CommentConverter.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/util/CommentConverter.java
@@ -8,11 +8,12 @@ import com.devcourse.be04daangnmarket.comment.dto.CreateCommentRequest;
 import java.util.List;
 
 public class CommentConverter {
-    public static Comment toEntity(CreateCommentRequest dto) {
-        return new Comment(dto.content());
+    public static Comment toEntity(CreateCommentRequest dto, Long userId) {
+        return new Comment(dto.content(), userId, dto.postId(), 0);
     }
 
     public static CommentResponse toResponse(Comment comment, List<ImageResponse> images) {
-        return new CommentResponse(comment.getContent(), images);
+        return new CommentResponse(comment.getContent(), comment.getMemberId(),
+                comment.getPostId(), comment.getCommentGroup(), comment.getSeq(), images);
     }
 }

--- a/src/test/java/com/devcourse/be04daangnmarket/comment/api/CommentRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/comment/api/CommentRestControllerTest.java
@@ -49,42 +49,34 @@ class CommentRestControllerTest {
     @MockBean
     private CommentService commentService;
 
-    @MockBean
-    private ImageService imageService;
-
     @Test
-    void 저장_성공() throws Exception {
+    void 댓글_저장_성공() throws Exception {
         //given
-        CreateCommentRequest request = new CreateCommentRequest("댓글");
-        String requestJson = objectMapper.writeValueAsString(request);
-        MockMultipartFile jsonFile = new MockMultipartFile("request", "request", "application/json", requestJson.getBytes(StandardCharsets.UTF_8));
-
-        MockMultipartFile imageFile = new MockMultipartFile("test", "test.jpeg", MediaType.IMAGE_JPEG_VALUE, "test".getBytes());
         List<MultipartFile> images = new ArrayList<>();
+        MockMultipartFile imageFile = new MockMultipartFile("구직_공고문", "구직_공고문.png", MediaType.IMAGE_JPEG_VALUE, "test".getBytes());
         images.add(imageFile);
+        CreateCommentRequest request = new CreateCommentRequest("댓글", 1L, images);
 
-        List<ImageResponse> imageResponses = new ArrayList<>();
-        ImageResponse imageResponse = new ImageResponse("test.jpeg", "C:\\Users\\User\\Desktop\\image\\17801b4d-d7b8-4ba6-9c7d-d9ba4cbf6b21-test.jpeg", "image/jpeg",
-                502868, DomainName.COMMENT, 1L);
-        imageResponses.add(imageResponse);
+        List<ImageResponse> imageResponseList1 = new ArrayList<>();
+        ImageResponse imageResponse1 = new ImageResponse("구직_공고문.png", "images/a8f468c1-d234-4c08-8235-63cc59f73a15-구직_공고문.png", "image/png",
+                898066, DomainName.COMMENT, 1L);
+        imageResponseList1.add(imageResponse1);
 
-        CommentResponse mockResponse = new CommentResponse("댓글", imageResponses);
+        CommentResponse mockResponse = new CommentResponse("댓글", 1L, 1L, 1, 0, imageResponseList1);
 
-        given(imageService.uploadImages(images, DomainName.COMMENT, 1L))
-                .willReturn(imageResponses);
-        given(commentService.create(request, images))
+//        given(imageService.uploadImages(images, DomainName.COMMENT, 1L))
+//                .willReturn(imageResponses);
+        given(commentService.create(request, 1L))
                 .willReturn(mockResponse);
 
         //when & then
         this.mockMvc.perform(multipart("/api/v1/comments")
-                        .file(jsonFile)
-                        .file("request", requestJson.getBytes())
                         .file(imageFile)
-                        .param("test.jpeg", "value"))
+                        .param("postId", "1L")
+                        .param("content", "댓글"))
                 .andExpect(status().isCreated())
                 .andDo(print());
     }
-
     @Test
     void 삭제_성공() throws Exception {
         //given
@@ -100,7 +92,7 @@ class CommentRestControllerTest {
     void 조회_성공() throws Exception {
         //given
         Long commentId = 1L;
-        CommentResponse response = new CommentResponse("댓글", null);
+        CommentResponse response = new CommentResponse("댓글", 1L, 1L, 1, 0, null);
         given(commentService.getDetail(commentId))
                 .willReturn(response);
 
@@ -114,8 +106,8 @@ class CommentRestControllerTest {
     @Test
     void 페이징_조회_성공() throws Exception {
         //given
-        CommentResponse response1 = new CommentResponse("댓글", null);
-        CommentResponse response2 = new CommentResponse("댓글", null);
+        CommentResponse response1 = new CommentResponse("댓글", 1L, 1L, 1, 0, null);
+        CommentResponse response2 = new CommentResponse("댓글", 1L, 1L, 1, 0, null);
 
         Pageable pageable = PageRequest.of(0, 10);
         PageImpl<CommentResponse> responses = new PageImpl<>(List.of(response1, response2), pageable, 2);
@@ -135,7 +127,7 @@ class CommentRestControllerTest {
     void 수정_성공() throws Exception {
         //given
         Long commentId = 1L;
-        CommentResponse response = new CommentResponse("변경 댓글", null);
+        CommentResponse response = new CommentResponse("댓글", 1L, 1L, 1, 0, null);
 
         UpdateCommentRequest request = new UpdateCommentRequest("변경 댓글");
         String requestJson = objectMapper.writeValueAsString(request);

--- a/src/test/java/com/devcourse/be04daangnmarket/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/comment/application/CommentServiceTest.java
@@ -40,7 +40,7 @@ class CommentServiceTest {
         Long commentId = 9L;
 
         //when & then
-        assertThatThrownBy(() -> commentService.delete(commentId))
+        assertThatThrownBy(() -> commentService.deleteReply(commentId))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(NOT_FOUND_COMMENT.getMessage());
     }
@@ -52,7 +52,7 @@ class CommentServiceTest {
         given(commentRepository.findById(comment.getId())).willReturn(Optional.of(comment));
 
         //when
-        commentService.delete(comment.getId());
+        commentService.deleteReply(comment.getId());
 
         // then
         assertThat(comment.getDeletedStatus()).isEqualTo(DeletedStatus.DELETED);

--- a/src/test/java/com/devcourse/be04daangnmarket/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/comment/application/CommentServiceTest.java
@@ -40,7 +40,7 @@ class CommentServiceTest {
         Long commentId = 9L;
 
         //when & then
-        assertThatThrownBy(() -> commentService.deleteReply(commentId))
+        assertThatThrownBy(() -> commentService.delete(commentId))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(NOT_FOUND_COMMENT.getMessage());
     }
@@ -52,7 +52,7 @@ class CommentServiceTest {
         given(commentRepository.findById(comment.getId())).willReturn(Optional.of(comment));
 
         //when
-        commentService.deleteReply(comment.getId());
+        commentService.delete(comment.getId());
 
         // then
         assertThat(comment.getDeletedStatus()).isEqualTo(DeletedStatus.DELETED);


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
댓글 도메인에 그룹(commentGroup)과 순서(seq)를 추가하여 계층 구조를 만들었습니다.
생성할 경우 하나의 댓글은 그룹을 만들고 그 안에서 같은 그룹 안에서 순서 값을 통해 대댓글을 만듭니다.
삭제할 경우 삭제하는 댓글의 PK값이 댓글인지, 대댓글인지를 판별하여 그룹을 삭제할 것인지 단일 삭제할 것 인지를 결정합니다.
