### PR TITLE
[KIM-99] 게시물 조회 시 조회 수 증가 기능 구현

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -29,6 +29,9 @@ import com.devcourse.be04daangnmarket.post.domain.Status;
 import com.devcourse.be04daangnmarket.post.domain.TransactionType;
 import com.devcourse.be04daangnmarket.post.dto.PostDto;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 @RestController
 @RequestMapping("api/v1/posts")
 public class PostRestController {
@@ -40,16 +43,18 @@ public class PostRestController {
 	}
 
 	@PostMapping
-	public ResponseEntity<PostDto.Response> createPost(PostDto.CreateRequest request,  @AuthenticationPrincipal User user) throws IOException {
-		PostDto.Response response = postService.create(user.getId(),request.title(), request.description()
+	public ResponseEntity<PostDto.Response> createPost(PostDto.CreateRequest request,
+		@AuthenticationPrincipal User user) throws IOException {
+		PostDto.Response response = postService.create(user.getId(), request.title(), request.description()
 			, request.price(), request.transactionType(), request.category(), request.receivedImages());
 
 		return new ResponseEntity<>(response, HttpStatus.CREATED);
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<PostDto.Response> getPost(@PathVariable Long id) {
-		PostDto.Response response = postService.getPost(id);
+	public ResponseEntity<PostDto.Response> getPost(@PathVariable Long id, HttpServletRequest req,
+		HttpServletResponse res) {
+		PostDto.Response response = postService.getPost(id, req, res);
 
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -3,6 +3,10 @@ package com.devcourse.be04daangnmarket.post.application;
 import static com.devcourse.be04daangnmarket.post.exception.ErrorMessage.*;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 
 import java.util.List;
@@ -24,6 +28,10 @@ import com.devcourse.be04daangnmarket.post.domain.Post;
 import com.devcourse.be04daangnmarket.post.domain.TransactionType;
 import com.devcourse.be04daangnmarket.post.dto.PostDto;
 import com.devcourse.be04daangnmarket.post.repository.PostRepository;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Service
 @Transactional(readOnly = true)
@@ -47,8 +55,13 @@ public class PostService {
 		return toResponse(post, images);
 	}
 
-	public PostDto.Response getPost(Long id) {
+	@Transactional
+	public PostDto.Response getPost(Long id, HttpServletRequest req, HttpServletResponse res) {
 		Post post = findPostById(id);
+		if (!isViewed(id, req, res)) {
+			post.updateView();
+			postRepository.save(post);
+		}
 		List<ImageResponse> images = imageService.getImages(DomainName.POST, id);
 
 		return toResponse(post, images);
@@ -138,5 +151,25 @@ public class PostService {
 			post.getStatus().getDescription(),
 			images
 		);
+	}
+
+	private boolean isViewed(Long id, HttpServletRequest req, HttpServletResponse res) {
+		String cookieName = Long.toString(id);
+		String cookieValue = Long.toString(id);
+
+		Cookie[] cookies = req.getCookies();
+
+		if (cookies != null) {
+			for (Cookie cookie : cookies)
+				if (cookie.getName().contains(cookieName))
+					return true;
+		}
+
+		Cookie cookie = new Cookie(cookieName, cookieValue);
+		cookie.setPath("/");
+		cookie.setMaxAge(60);
+		res.addCookie(cookie);
+
+		return false;
 	}
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
@@ -138,4 +138,8 @@ public class Post extends BaseEntity {
 		}
 	}
 
+	public void updateView() {
+		this.views++;
+	}
+
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/view/PostController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/view/PostController.java
@@ -4,43 +4,47 @@ import com.devcourse.be04daangnmarket.post.application.PostService;
 import com.devcourse.be04daangnmarket.post.domain.Category;
 import com.devcourse.be04daangnmarket.post.domain.TransactionType;
 import com.devcourse.be04daangnmarket.post.dto.PostDto;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 @Controller
 public class PostController {
 
-    private final PostService postService;
+	private final PostService postService;
 
-    public PostController(PostService postService) {
-        this.postService = postService;
-    }
+	public PostController(PostService postService) {
+		this.postService = postService;
+	}
 
-    @GetMapping(value = "/posts/new")
-    public String newPost(Model model) {
-        model.addAttribute("categories", Category.values());
-        model.addAttribute("transactionTypes", TransactionType.values());
+	@GetMapping(value = "/posts/new")
+	public String newPost(Model model) {
+		model.addAttribute("categories", Category.values());
+		model.addAttribute("transactionTypes", TransactionType.values());
 
-        return "newPost";
-    }
+		return "newPost";
+	}
 
-    @GetMapping(value = "/posts/{id}")
-    public String getPost(@PathVariable Long id, Model model) {
-        model.addAttribute("id", id);
+	@GetMapping(value = "/posts/{id}")
+	public String getPost(@PathVariable Long id, Model model) {
+		model.addAttribute("id", id);
 
-        return "post";
-    }
+		return "post";
+	}
 
-    @GetMapping(value = "/posts/update/{id}")
-    public String updatePost(@PathVariable Long id, Model model) {
-        PostDto.Response post = postService.getPost(id);
+	@GetMapping(value = "/posts/update/{id}")
+	public String updatePost(@PathVariable Long id, Model model, HttpServletRequest req, HttpServletResponse res) {
+		PostDto.Response post = postService.getPost(id, req, res);
 
-        model.addAttribute("post", post);
-        model.addAttribute("categories", Category.values());
-        model.addAttribute("transactionTypes", TransactionType.values());
+		model.addAttribute("post", post);
+		model.addAttribute("categories", Category.values());
+		model.addAttribute("transactionTypes", TransactionType.values());
 
-        return "updatePost";
-    }
+		return "updatePost";
+	}
 }

--- a/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
@@ -82,7 +82,7 @@ class PostRestControllerTest {
 			TransactionType.SALE.getDescription(), Category.DIGITAL_DEVICES.getDescription(),
 			Status.FOR_SALE.getDescription(), null);
 
-		when(postService.getPost(1L)).thenReturn(mockResponse);
+		when(postService.getPost(1L, null, null)).thenReturn(mockResponse);
 
 		// when then
 		mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/posts/" + postId))

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -13,20 +13,26 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.devcourse.be04daangnmarket.common.jwt.JwtTokenProvider;
 import com.devcourse.be04daangnmarket.image.application.ImageService;
 import com.devcourse.be04daangnmarket.post.domain.Category;
 import com.devcourse.be04daangnmarket.post.domain.Post;
 import com.devcourse.be04daangnmarket.post.domain.TransactionType;
 import com.devcourse.be04daangnmarket.post.dto.PostDto;
 import com.devcourse.be04daangnmarket.post.repository.PostRepository;
+
+import jakarta.servlet.http.Cookie;
 
 @SpringBootTest
 class PostServiceTest {
@@ -39,6 +45,9 @@ class PostServiceTest {
 
 	@Mock
 	private ImageService imageService;
+
+	@MockBean
+	private JwtTokenProvider jwtTokenProvider;
 
 	@Test
 	@DisplayName("게시글 등록 성공")
@@ -88,11 +97,54 @@ class PostServiceTest {
 		when(postRepository.findById(postId)).thenReturn(Optional.of(post));
 
 		// when
-		PostDto.Response response = postService.getPost(postId);
+		PostDto.Response response = postService.getPost(postId, null, null);
 
 		// then
 		assertNotNull(response);
 		assertEquals(post.getId(), response.id());
+		verify(postRepository, times(1)).findById(postId);
+	}
+
+	@Test
+	@DisplayName("사용자가 게시물을 처음 조회 시 조회수가 1 증가한다")
+	void viewUpdateSuccessTest() {
+		// given
+		Long postId = 1L;
+		Post post = new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+			Category.DIGITAL_DEVICES);
+		when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+
+		MockHttpServletRequest req = new MockHttpServletRequest();
+		MockHttpServletResponse res = new MockHttpServletResponse();
+
+		// when
+		PostDto.Response response = postService.getPost(postId, req, res);
+
+		// then
+		assertNotNull(response);
+		assertEquals(1, post.getViews());
+		verify(postRepository, times(1)).findById(postId);
+	}
+
+	@Test
+	@DisplayName("사용자가 게시물을 재 조회 시 조회수가 증가하지 않는다")
+	void viewUpdateFailTest() {
+		// given
+		Long postId = 1L;
+		Post post = new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+			Category.DIGITAL_DEVICES);
+		when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+
+		MockHttpServletRequest req = new MockHttpServletRequest();
+		MockHttpServletResponse res = new MockHttpServletResponse();
+		req.setCookies(new Cookie(postId.toString(), postId.toString()));
+
+		// when
+		PostDto.Response response = postService.getPost(postId, req, res);
+
+		// then
+		assertNotNull(response);
+		assertEquals(0, post.getViews());
 		verify(postRepository, times(1)).findById(postId);
 	}
 


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 게시물 조회수 증가 기능을 구현했습니다

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] 쿠기 기반 중복 방지를 고려한 조회수 업데이트 기능 구현

### 🐰 PR POINT  <!-- PR에서 중점적으로 봐야할 부문을 작성해주세요. -->
- 쿠키를 사용해 중복방지를 고려한 조회수 증가 기능을 구현했습니다.
- 사용자가 게시물 첫 조회 시 게시물 id 기준 쿠키를 만들고, 이를 조건으로 조회 수 업데이트 수행 여부를 결정하도록 했습니다.
- 테스트를 위해 쿠키 유효시간을 1분으로 설정했습니다.

### 🥕 리뷰어에게 하고싶은 말  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 조회수 관련해 많은 부분을 시도했는데 제 역량으로 쿠키가 적절했습니다.
- 하지만 쿠키의 저장용량 등 한계가 있습니다. 추후 고도화 기간 때 더 깊게 구현할 예정입니다.
