### PR TITLE
[KIM 176] 게시글 상품 구매시 구매자 정보 저장 기능 구현

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -92,7 +93,7 @@ public class PostRestController {
 	}
 
 	@GetMapping("/member/{memberId}")
-	public ResponseEntity<Page<PostDto.Response>> getPostByCategory(
+	public ResponseEntity<Page<PostDto.Response>> getPostByMemberId(
 		@PathVariable @NotNull Long memberId,
 		@RequestParam(defaultValue = "0") int page
 	) {
@@ -134,9 +135,19 @@ public class PostRestController {
 	@PatchMapping("/{id}/status")
 	public ResponseEntity<PostDto.Response> updatePostStatus(
 		@PathVariable @NotNull Long id,
-		@Valid PostDto.StatusUpdateRequest request
+		@RequestBody @Valid PostDto.StatusUpdateRequest request
 	) {
 		PostDto.Response response = postService.updateStatus(id, request.status());
+
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@PatchMapping("/{id}/purchase")
+	public ResponseEntity<PostDto.Response> purchaseProduct(
+		@PathVariable @NotNull Long id,
+		@RequestBody @Valid PostDto.BuyerUpdateRequest request
+	) {
+		PostDto.Response response = postService.purchaseProduct(id, request.buyerId());
 
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -123,15 +123,24 @@ public class PostService {
 		return toResponse(post, images);
 	}
 
-	private Post findPostById(Long id) {
-		return postRepository.findById(id)
-			.orElseThrow(() -> new NoSuchElementException(NOT_FOUND_POST.getMessage()));
-	}
-
 	@Transactional
 	public void delete(Long id) {
 		postRepository.deleteById(id);
 		imageService.deleteAllImages(DomainName.POST, id);
+	}
+
+	@Transactional
+	public PostDto.Response purchaseProduct(Long id, Long buyerId) {
+		Post post = findPostById(id);
+		post.purchased(buyerId);
+		List<ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
+
+		return toResponse(post, images);
+	}
+
+	private Post findPostById(Long id) {
+		return postRepository.findById(id)
+			.orElseThrow(() -> new NoSuchElementException(NOT_FOUND_POST.getMessage()));
 	}
 
 	private PostDto.Response toResponse(Post post, List<ImageResponse> images) {
@@ -145,7 +154,8 @@ public class PostService {
 			post.getTransactionType().getDescription(),
 			post.getCategory().getDescription(),
 			post.getStatus().getDescription(),
-			images
+			images,
+			post.getBuyerId()
 		);
 	}
 
@@ -154,7 +164,7 @@ public class PostService {
 		String cookieValue = Long.toString(id);
 		Cookie[] cookies = req.getCookies();
 
-		if(cookies == null )
+		if (cookies == null)
 			return false;
 
 		for (Cookie cookie : cookies)

--- a/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/domain/Post.java
@@ -49,6 +49,8 @@ public class Post extends BaseEntity {
 	@ColumnDefault("'FOR_SALE'")
 	private Status status;
 
+	private Long buyerId;
+
 	@Column(columnDefinition = "TIMESTAMP")
 	private LocalDateTime pullUpAt;
 
@@ -114,6 +116,10 @@ public class Post extends BaseEntity {
 		return status;
 	}
 
+	public Long getBuyerId() {
+		return buyerId;
+	}
+
 	public LocalDateTime getPullUpAt() {
 		return pullUpAt;
 	}
@@ -141,9 +147,13 @@ public class Post extends BaseEntity {
 	public void updateStatus(Status status) {
 		this.status = status;
 	}
-  
+
 	public void updateView() {
 		this.views++;
+	}
+
+	public void purchased(Long buyerId) {
+		this.buyerId = buyerId;
 	}
 
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
@@ -60,6 +60,12 @@ public class PostDto {
 	) {
 	}
 
+	public record BuyerUpdateRequest(
+		@NotNull(message = "구매자 정보는 필수 입니다.")
+		Long buyerId
+	) {
+	}
+
 	public record Response(
 		Long id,
 		Long memberId,

--- a/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
@@ -70,7 +70,8 @@ public class PostDto {
 		String transactionType,
 		String category,
 		String status,
-		List<ImageResponse> images
+		List<ImageResponse> images,
+		Long buyerId
 	) {
 	}
 

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -361,4 +361,29 @@ class PostServiceTest {
 		verify(postRepository, times(1)).deleteById(postId);
 	}
 
+	@Test
+	@DisplayName("게시글 상품 구매시 게시글 구매자 ID 컬럼 저장")
+	void PostServiceTest() {
+	    // given
+	    Long postId =1L;
+		Long buyerId = 1L;
+		Post post = new Post(
+			1L,
+			"keyboard~!",
+			"this keyboard is good",
+			50000, TransactionType.SALE,
+			Category.DIGITAL_DEVICES
+		);
+
+		when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+
+	    // when
+	    PostDto.Response response = postService.purchaseProduct(postId, buyerId);
+
+		// then
+		assertEquals(buyerId, response.buyerId());
+		verify(postRepository, times(1)).findById(1L);
+
+	}
+
 }


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 사용자가 게시물의 상품 구매시 구매 정보 기록에 대한 기능을 구현했습니다.

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] 게시물의 구매자 정보 저장 기능 구현 
- [x] 게시물의 구매자 정보 저장 API 구현 

### 🐰 PR POINT  <!-- PR에서 중점적으로 봐야할 부문을 작성해주세요. -->
- 소규모 정보의 수정이라 생각하여 patch http 메서드로 받도록 했습니다. 

### 🥕 리뷰어에게 하고싶은 말  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 사용자에서 api 를 만들까 게시글에서 api만들까 고민하다가 선택이라 생각해서 게시글에 만들었습니다.

