### PR TITLE
[KIM-184] 게시글의 댓글을 작성한 사용자 목록 조회기능 구현

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
@@ -13,6 +13,8 @@ import com.devcourse.be04daangnmarket.comment.exception.NotFoundException;
 import com.devcourse.be04daangnmarket.comment.repository.CommentRepository;
 import com.devcourse.be04daangnmarket.comment.util.CommentConverter;
 import com.devcourse.be04daangnmarket.member.application.MemberService;
+import com.devcourse.be04daangnmarket.member.domain.Member;
+import com.devcourse.be04daangnmarket.member.dto.MemberDto;
 import com.devcourse.be04daangnmarket.post.application.PostService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -23,6 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.devcourse.be04daangnmarket.comment.exception.ExceptionMessage.NOT_FOUND_COMMENT;
 @Transactional(readOnly = true)
@@ -155,5 +158,29 @@ public class CommentService {
 
     private boolean isExistImages(List<MultipartFile> files) {
         return !files.get(START_NUMBER).isEmpty();
+    }
+
+    public Page<MemberDto.Response> getMemberByPostId(Long postId, Pageable pageable) {
+        Long writerId = postService.findPostById(postId).getMemberId();
+
+        List<MemberDto.Response> responses = commentRepository.findDistinctMemberIdsByPostId(postId).stream()
+                .filter(memberId -> !memberId.equals(writerId))
+                .map(memberId -> {
+                    Member member = memberService.getMember(memberId);
+
+                    return new MemberDto.Response(
+                            member.getId(),
+                            member.getUsername(),
+                            member.getPhoneNumber(),
+                            member.getEmail(),
+                            member.getTemperature(),
+                            member.getStatus(),
+                            member.getCreatedAt(),
+                            member.getUpdatedAt()
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(responses, pageable, responses.size());
     }
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
@@ -25,7 +25,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.devcourse.be04daangnmarket.comment.exception.ExceptionMessage.NOT_FOUND_COMMENT;
 @Transactional(readOnly = true)
@@ -160,11 +159,10 @@ public class CommentService {
         return !files.get(START_NUMBER).isEmpty();
     }
 
-    public Page<MemberDto.Response> getMemberByPostId(Long postId, Pageable pageable) {
+    public Page<MemberDto.Response> getCommenterByPostId(Long postId, Pageable pageable) {
         Long writerId = postService.findPostById(postId).getMemberId();
 
-        List<MemberDto.Response> responses = commentRepository.findDistinctMemberIdsByPostId(postId).stream()
-                .filter(memberId -> !memberId.equals(writerId))
+         return commentRepository.findDistinctMemberIdsByPostIdAndNotInWriterId(postId, writerId, pageable)
                 .map(memberId -> {
                     Member member = memberService.getMember(memberId);
 
@@ -178,9 +176,6 @@ public class CommentService {
                             member.getCreatedAt(),
                             member.getUpdatedAt()
                     );
-                })
-                .collect(Collectors.toList());
-
-        return new PageImpl<>(responses, pageable, responses.size());
+                });
     }
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/repository/CommentRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/repository/CommentRepository.java
@@ -26,6 +26,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c WHERE c.commentGroup=:commentGroup AND c.seq > 0 ORDER BY c.seq ASC")
     List<Comment> findRepliesByCommentGroup(@Param("commentGroup") int commentGroup);
 
-    @Query("SELECT DISTINCT c.memberId FROM Comment c WHERE c.postId=:postId")
-    List<Long> findDistinctMemberIdsByPostId (@Param("postId") Long postId);
+    @Query("SELECT DISTINCT c.memberId FROM Comment c WHERE c.postId=:postId AND c.memberId <> :writerId")
+    Page<Long> findDistinctMemberIdsByPostIdAndNotInWriterId(@Param("postId") Long postId, @Param("writerId") Long writerId, Pageable pageable);
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/repository/CommentRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/repository/CommentRepository.java
@@ -1,6 +1,8 @@
 package com.devcourse.be04daangnmarket.comment.repository;
 
 import com.devcourse.be04daangnmarket.comment.domain.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +25,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT c FROM Comment c WHERE c.commentGroup=:commentGroup AND c.seq > 0 ORDER BY c.seq ASC")
     List<Comment> findRepliesByCommentGroup(@Param("commentGroup") int commentGroup);
+
+    @Query("SELECT DISTINCT c.memberId FROM Comment c WHERE c.postId=:postId")
+    List<Long> findDistinctMemberIdsByPostId (@Param("postId") Long postId);
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -7,7 +7,6 @@ import com.devcourse.be04daangnmarket.member.dto.MemberDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -168,7 +167,7 @@ public class PostRestController {
 	@GetMapping("/{id}/communicationMembers")
  	public ResponseEntity<Page<MemberDto.Response>> getCommunicationMembers(@PathVariable Long id,
 																	@PageableDefault(page = 0, size = 10) Pageable pageable) {
-		Page<MemberDto.Response> responses = commentService.getMemberByPostId(id, pageable);
+		Page<MemberDto.Response> responses = commentService.getCommenterByPostId(id, pageable);
 
 		return ResponseEntity.status(HttpStatus.OK).body(responses);
 	}

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -2,9 +2,13 @@ package com.devcourse.be04daangnmarket.post.api;
 
 import java.io.IOException;
 
+import com.devcourse.be04daangnmarket.comment.application.CommentService;
+import com.devcourse.be04daangnmarket.member.dto.MemberDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,9 +40,11 @@ public class PostRestController {
 
 	private final int PAGE_SIZE = 10;
 	private final PostService postService;
+	private final CommentService commentService;
 
-	public PostRestController(PostService postService) {
+	public PostRestController(PostService postService, CommentService commentService) {
 		this.postService = postService;
+		this.commentService = commentService;
 	}
 
 	@PostMapping
@@ -159,4 +165,11 @@ public class PostRestController {
 		return ResponseEntity.noContent().build();
 	}
 
+	@GetMapping("/{id}/communicationMembers")
+ 	public ResponseEntity<Page<MemberDto.Response>> getCommunicationMembers(@PathVariable Long id,
+																	@PageableDefault(page = 0, size = 10) Pageable pageable) {
+		Page<MemberDto.Response> responses = commentService.getMemberByPostId(id, pageable);
+
+		return ResponseEntity.status(HttpStatus.OK).body(responses);
+	}
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -147,11 +147,6 @@ public class PostService {
 		return toResponse(post, images);
 	}
 
-	private Post findPostById(Long id) {
-		return postRepository.findById(id)
-			.orElseThrow(() -> new NoSuchElementException(NOT_FOUND_POST.getMessage()));
-	}
-
 	private PostDto.Response toResponse(Post post, List<ImageResponse> images) {
 		MemberDto.Response member = memberService.getProfile(post.getMemberId());
 


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
-  게시글의 댓글을 작성한 사용자 정보 목록을 조회하는 기능입니다.

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] 게시글의 댓글을 작성한 구매자 목록 조회기능을 구현하다

### 🥕 리뷰어에게 하고싶은 말  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
CommentService에서 게시글 작성자가 댓글을 달았을 경우를 위해 writerId를 통해 목록에서 제외하도록 하였습니다.
filter()를 통해서 처리하였는데 혹시 다른 좋은 방법이 있었는지 같이 생각해주시면 감사하겠습니다!
