### PR TITLE
[KIM-181] 댓글 대댓글 페이지 구현

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
@@ -129,6 +129,7 @@ public class CommentService {
                             comment.getContent(),
                             commentImages,
                             replyCommentResponses,
+                            comment.getCommentGroup(),
                             comment.getCreatedAt(),
                             comment.getUpdatedAt()
                     )

--- a/src/main/java/com/devcourse/be04daangnmarket/comment/dto/CommentDto.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/dto/CommentDto.java
@@ -72,6 +72,8 @@ public class CommentDto {
 
             List<CommentResponse> replyComments,
 
+            int commentGroup,
+
             LocalDateTime createdAt,
 
             LocalDateTime updatedAt

--- a/src/main/java/com/devcourse/be04daangnmarket/post/view/PostController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/view/PostController.java
@@ -71,4 +71,11 @@ public class PostController {
 
         return "communicationList";
     }
+
+    @GetMapping("/posts/{id}/comments")
+    public String comments(@PathVariable Long id, Model model) {
+        model.addAttribute("id", id);
+
+        return "comments";
+    }
 }

--- a/src/main/resources/templates/comments.html
+++ b/src/main/resources/templates/comments.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<script th:src="@{https://unpkg.com/axios/dist/axios.min.js}"></script>
+<head>
+    <meta charset="utf-8">
+    <title>comments</title>
+    <link rel="stylesheet" href="https://unpkg.com/mvp.css@1.12/mvp.css">
+</head>
+
+<body>
+<form id="uploadComments" enctype="multipart/form-data">
+    <div>
+        <label for="content">댓글</label>
+        <input type="text" id="content" name="content" placeholder="제목">
+    </div>
+    <div>
+        <label for="files">파일 선택:</label>
+        <input type="file" id="files" name="files" multiple/>
+    </div>
+    <div>
+        <button type="button" onclick="uploadComments()">댓글 작성</button>
+    </div>
+</form>
+
+<div id="commentList">
+</div>
+
+<script>
+    const postId = [[${id}]];
+    const commentList = document.getElementById('commentList');
+    document.addEventListener("DOMContentLoaded", loadComments);
+
+    function loadComments() {
+        axios.get('/api/v1/posts/' + postId + '/comments')
+            .then(response => {
+                displayComments(response.data.content)
+            })
+            .catch(error => {
+                alert("오류가 발생했습니다. \n" + error.response.data);
+                console.log(error);
+            });
+    }
+
+    function uploadComments() {
+        const formData = new FormData(document.getElementById('uploadComments'));
+        formData.append("postId", postId);
+
+        const headers = {
+            'Authorization': localStorage.getItem('token'),
+            'Content-Type': "multipart/form-data"
+        }
+
+        axios.post('/api/v1/comments', formData, {headers: headers})
+            .then(function (response) {
+                loadComments();
+            })
+            .catch(function (error) {
+                console.error(error);
+            });
+    }
+
+    function displayComments(comments) {
+        if (comments.length === 0) {
+            return;
+        }
+        commentList.innerHTML = '';
+        comments.forEach(comment => {
+            const cardElement = createCardElement(comment);
+            commentList.appendChild(cardElement);
+        });
+
+    }
+
+    function createCardElement(comment) {
+        const cardElement = document.createElement('div');
+        cardElement.classList.add('card');
+        cardElement.innerHTML = `
+    <div class="comment">
+        <div style="float: left; margin-right: 20px">
+          <img src="../../${comment.images[0].path}" alt="이미지" style="width: 120px; height: 120px">
+        </div>
+        <p>${comment.content}</p>
+        <textarea class="replyContent" placeholder="댓글 또는 대댓글 작성..."></textarea>
+        <input type="hidden" class="postId" value="${comment.postId}">
+        <input type="hidden" class="commentGroup" value="${comment.commentGroup}">
+        <button class="addReply">대댓글 작성</button>
+    </div>
+    <div class="replies">
+    </div>
+    <hr>
+        `;
+
+        const addReplyButton = cardElement.querySelector('.addReply');
+        addReplyButton.addEventListener('click', () => {
+            const content = cardElement.querySelector('.replyContent').value;
+            const postId = cardElement.querySelector('.postId').value;
+            const commentGroup = cardElement.querySelector('.commentGroup').value;
+            uploadReply(postId, commentGroup, content);
+        });
+
+        const repliesContainer = cardElement.querySelector('.replies');
+        const replyComments = comment.replyComments;
+        replyComments.forEach(reply => {
+            const replyElement = document.createElement('div');
+            replyElement.classList.add('comment');
+            replyElement.innerHTML = `<p>${reply.content}</p>`;
+            repliesContainer.appendChild(replyElement);
+        });
+
+        return cardElement;
+    }
+
+    function uploadReply(postId, commentGroup, content) {
+
+        const headers = {
+            'Authorization': localStorage.getItem('token'),
+            'Content-Type': "multipart/form-data"
+        }
+
+        axios.post(`/api/v1/comments/reply`, {
+                content: content,
+                postId: postId,
+                commentGroup: commentGroup
+            }
+            , {headers: headers}
+        ).then(response => {
+            console.log(JSON.stringify(response));
+            loadComments();
+
+        }).catch(error => {
+            alert("오류가 발생했습니다. \n" + error.response.data);
+            console.log(error);
+        })
+    }
+
+</script>
+</body>
+</html>

--- a/src/test/java/com/devcourse/be04daangnmarket/comment/api/CommentRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/comment/api/CommentRestControllerTest.java
@@ -180,8 +180,8 @@ class CommentRestControllerTest {
     void 페이징_조회_성공() throws Exception {
         //given
         Long postId = 1L;
-        CommentDto.PostCommentResponse mockResponse1 = new CommentDto.PostCommentResponse(1L, 1L, "username", 1L, "게시글", "댓글", null, null, LocalDateTime.now(), LocalDateTime.now());
-        CommentDto.PostCommentResponse mockResponse2 = new CommentDto.PostCommentResponse(2L, 1L, "username", 1L, "게시글", "댓글2", null, null, LocalDateTime.now(), LocalDateTime.now());
+        CommentDto.PostCommentResponse mockResponse1 = new CommentDto.PostCommentResponse(1L, 1L, "username", 1L, "게시글", "댓글", null, null, 1, LocalDateTime.now(), LocalDateTime.now());
+        CommentDto.PostCommentResponse mockResponse2 = new CommentDto.PostCommentResponse(2L, 1L, "username", 1L, "게시글", "댓글2", null, null, 1, LocalDateTime.now(), LocalDateTime.now());
 
         Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         List<CommentDto.PostCommentResponse> fakeResponses = List.of(mockResponse1, mockResponse2);

--- a/src/test/java/com/devcourse/be04daangnmarket/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/comment/application/CommentServiceTest.java
@@ -2,7 +2,6 @@ package com.devcourse.be04daangnmarket.comment.application;
 
 import com.devcourse.be04daangnmarket.comment.domain.Comment;
 import com.devcourse.be04daangnmarket.comment.dto.CommentDto;
-import com.devcourse.be04daangnmarket.comment.exception.NotFoundCommentException;
 import com.devcourse.be04daangnmarket.comment.repository.CommentRepository;
 import com.devcourse.be04daangnmarket.common.constant.Status;
 import com.devcourse.be04daangnmarket.image.application.ImageService;
@@ -28,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static com.devcourse.be04daangnmarket.comment.exception.ErrorMessage.NOT_FOUND_COMMENT;
@@ -61,7 +61,7 @@ class CommentServiceTest {
 
         //when & then
         assertThatThrownBy(() -> commentService.delete(commentId))
-                .isInstanceOf(NotFoundCommentException.class)
+                .isInstanceOf(NoSuchElementException.class)
                 .hasMessage(NOT_FOUND_COMMENT.getMessage());
     }
 


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 댓글 대댓글 기능에 대한  페이지를 구현했습니다.

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] 댓글 대댓글 페이지 구현

### 🐰 PR POINT  <!-- PR에서 중점적으로 봐야할 부문을 작성해주세요. -->
- 페이지 첫 로드시, 댓글, 대댓글 생성 이벤트 발생 시 전체조회를 통해 화면에 렌더링하는 로직입니다.

### 🥕 리뷰어에게 하고싶은 말  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 백앤드 api를 확인할 수 있도록 긴딘하게 페이지를 구성했습니다.
- 댓글은 이미지와 텍스트, 대댓글은 텍스트만 노출되도록 했습니다.
- 어색한 네이밍이 있는데 고치다보니 복잡해서 그대로 두었습니다. 일정과 우선순위를 고려했을때 해당부분은 넘어가는게 적합하다고판단했습니다.

