### PR TITLE
[KIM-999] 중복 API 통합 및 커서 페이지네이션 구현

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/member/api/MemberRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/member/api/MemberRestController.java
@@ -10,6 +10,7 @@ import com.devcourse.be04daangnmarket.post.dto.PostDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -79,17 +80,17 @@ public class MemberRestController {
     }
 
     @GetMapping("/{id}/sale")
-    public ResponseEntity<Page<PostDto.Response>> getSaleList(@PathVariable Long id, @RequestParam(defaultValue = "0") int page) {
+    public ResponseEntity<Slice<PostDto.Response>> getSaleList(@PathVariable Long id, @RequestParam(defaultValue = "0") int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("id").descending());
-        Page<PostDto.Response> saleList = postService.getAllPost(pageable, null, id, null, null);
+        Slice<PostDto.Response> saleList = postService.getAllPost(pageable,null,  null, id, null, null);
 
         return ResponseEntity.ok(saleList);
     }
 
     @GetMapping("/{id}/purchase")
-    public ResponseEntity<Page<PostDto.Response>> getPurchaseList(@PathVariable Long id, @RequestParam(defaultValue = "0") int page) {
+    public ResponseEntity<Slice<PostDto.Response>> getPurchaseList(@PathVariable Long id, @RequestParam(defaultValue = "0") int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("id").descending());
-        Page<PostDto.Response> purchaseList = postService.getAllPost(pageable, null, null, null, id);
+        Slice<PostDto.Response> purchaseList = postService.getAllPost(pageable,null, null, null, null, id);
 
         return ResponseEntity.ok(purchaseList);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/member/api/MemberRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/member/api/MemberRestController.java
@@ -81,7 +81,7 @@ public class MemberRestController {
     @GetMapping("/{id}/sale")
     public ResponseEntity<Page<PostDto.Response>> getSaleList(@PathVariable Long id, @RequestParam(defaultValue = "0") int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("id").descending());
-        Page<PostDto.Response> saleList = postService.getPostByMemberId(id, pageable);
+        Page<PostDto.Response> saleList = postService.getAllPost(pageable, null, id, null, null);
 
         return ResponseEntity.ok(saleList);
     }
@@ -89,7 +89,7 @@ public class MemberRestController {
     @GetMapping("/{id}/purchase")
     public ResponseEntity<Page<PostDto.Response>> getPurchaseList(@PathVariable Long id, @RequestParam(defaultValue = "0") int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("id").descending());
-        Page<PostDto.Response> purchaseList = postService.getPostByBuyerId(id, pageable);
+        Page<PostDto.Response> purchaseList = postService.getAllPost(pageable, null, null, null, id);
 
         return ResponseEntity.ok(purchaseList);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -62,12 +63,13 @@ public class PostRestController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<Page<PostDto.Response>> getAllPost(@RequestParam(required = false) Category category,
-                                                             @RequestParam(required = false) Long memberId,
-                                                             @RequestParam(required = false) String title,
-                                                             @RequestParam(required = false) Long buyerId,
-                                                             @PageableDefault(page = 0, size = PAGE_SIZE, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<PostDto.Response> responses = postService.getAllPost(pageable, category, memberId, title, buyerId);
+    public ResponseEntity<Slice<PostDto.Response>> getAllPost(@RequestParam(required = false) Category category,
+                                                              @RequestParam(required = false) Long memberId,
+                                                              @RequestParam(required = false) String title,
+                                                              @RequestParam(required = false) Long buyerId,
+                                                              @RequestParam(required = false) Long id,
+                                                              @PageableDefault(page = 0, size = PAGE_SIZE, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Slice<PostDto.Response> responses = postService.getAllPost(pageable, id, category, memberId, title, buyerId);
 
         return ResponseEntity.ok(responses);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -10,12 +10,11 @@ import com.devcourse.be04daangnmarket.post.dto.PostDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -62,39 +61,15 @@ public class PostRestController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping
-    public ResponseEntity<Page<PostDto.Response>> getAllPost(@RequestParam(defaultValue = "0") int page) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("id").descending());
-        Page<PostDto.Response> responses = postService.getAllPost(pageable);
+    @GetMapping("/search")
+    public ResponseEntity<Page<PostDto.Response>> getAllPost(@RequestParam(required = false) Category category,
+                                                             @RequestParam(required = false) Long memberId,
+                                                             @RequestParam(required = false) String title,
+                                                             @RequestParam(required = false) Long buyerId,
+                                                             @PageableDefault(page = 0, size = PAGE_SIZE, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<PostDto.Response> responses = postService.getAllPost(pageable, category, memberId, title, buyerId);
 
         return ResponseEntity.ok(responses);
-    }
-
-    @GetMapping("/category")
-    public ResponseEntity<Page<PostDto.Response>> getPostByCategory(@RequestParam @NotNull Category category,
-                                                                    @RequestParam(defaultValue = "0") int page) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("id").descending());
-        Page<PostDto.Response> response = postService.getPostByCategory(category, pageable);
-
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/member/{memberId}")
-    public ResponseEntity<Page<PostDto.Response>> getPostByMemberId(@PathVariable @NotNull Long memberId,
-                                                                    @RequestParam(defaultValue = "0") int page) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("id").descending());
-        Page<PostDto.Response> response = postService.getPostByMemberId(memberId, pageable);
-
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/search")
-    public ResponseEntity<Page<PostDto.Response>> getPostByKeyword(@RequestParam @NotBlank String keyword,
-                                                                   @RequestParam(defaultValue = "0") int page) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("id").descending());
-        Page<PostDto.Response> response = postService.getPostByKeyword(keyword, pageable);
-
-        return ResponseEntity.ok(response);
     }
 
     @PutMapping("/{id}")
@@ -139,8 +114,7 @@ public class PostRestController {
 
     @GetMapping("/{postId}/comments")
     public ResponseEntity<Page<CommentDto.PostCommentResponse>> getPostComments(@PathVariable Long postId,
-                                                                                @RequestParam(defaultValue = "0") int page) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("createdAt").descending());
+                                                                                @PageableDefault(page = 0, size = PAGE_SIZE, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<CommentDto.PostCommentResponse> response = commentService.getPostComments(postId, pageable);
 
         return ResponseEntity.ok(response);
@@ -148,8 +122,7 @@ public class PostRestController {
 
     @GetMapping("/{id}/communicationMembers")
     public ResponseEntity<Page<MemberDto.Response>> getCommunicationMembers(@PathVariable Long id,
-                                                                            @RequestParam(defaultValue = "0") int page) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+                                                                            @PageableDefault(page = 0, size = PAGE_SIZE) Pageable pageable) {
         Page<MemberDto.Response> responses = commentService.getCommenterByPostId(id, pageable);
 
         return ResponseEntity.ok(responses);

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import com.devcourse.be04daangnmarket.image.dto.ImageDto;
+import com.devcourse.be04daangnmarket.post.repository.PostCriteriaRepository;
 import com.devcourse.be04daangnmarket.post.util.PostConverter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,11 +35,13 @@ public class PostService {
 	private final PostRepository postRepository;
 	private final ImageService imageService;
 	private final MemberService memberService;
+	private final PostCriteriaRepository postCriteriaRepository;
 
-	public PostService(PostRepository postRepository, ImageService imageService, MemberService memberService) {
+	public PostService(PostRepository postRepository, ImageService imageService, MemberService memberService, PostCriteriaRepository postCriteriaRepository) {
 		this.postRepository = postRepository;
 		this.imageService = imageService;
 		this.memberService = memberService;
+		this.postCriteriaRepository = postCriteriaRepository;
 	}
 
 	@Transactional
@@ -79,44 +82,12 @@ public class PostService {
 		return PostConverter.toResponse(post, images, username);
 	}
 
-	public Page<PostDto.Response> getAllPost(Pageable pageable) {
-		return postRepository.findAll(pageable).map(post -> {
-			List<ImageDto.ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
-			String username = getUsername(post.getMemberId());
-
-			return PostConverter.toResponse(post, images, username);
-		});
-	}
-
-	public Page<PostDto.Response> getPostByCategory(Category category, Pageable pageable) {
-		return postRepository.findByCategory(category, pageable).map(post -> {
-			List<ImageDto.ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
-			String username = getUsername(post.getMemberId());
-
-			return PostConverter.toResponse(post, images, username);
-		});
-	}
-
-	public Page<PostDto.Response> getPostByMemberId(Long memberId, Pageable pageable) {
-		return postRepository.findByMemberId(memberId, pageable).map(post -> {
-			List<ImageDto.ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
-			String username = getUsername(post.getMemberId());
-
-			return PostConverter.toResponse(post, images, username);
-		});
-	}
-
-	public Page<PostDto.Response> getPostByKeyword(String keyword, Pageable pageable) {
-		return postRepository.findByTitleContaining(keyword, pageable).map(post -> {
-			List<ImageDto.ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
-			String username = getUsername(post.getMemberId());
-
-			return PostConverter.toResponse(post, images, username);
-		});
-	}
-
-	public Page<PostDto.Response> getPostByBuyerId(Long buyerId, Pageable pageable) {
-		return postRepository.findByBuyerId(buyerId, pageable).map(post -> {
+	public Page<PostDto.Response> getAllPost(Pageable pageable,
+											 Category category,
+											 Long memberId,
+											 String title,
+											 Long buyerId) {
+		return postCriteriaRepository.findAllByOffsetPaging(pageable, category, memberId, title, buyerId).map(post -> {
 			List<ImageDto.ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
 			String username = getUsername(post.getMemberId());
 

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -11,6 +11,7 @@ import com.devcourse.be04daangnmarket.post.repository.PostCriteriaRepository;
 import com.devcourse.be04daangnmarket.post.util.PostConverter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -82,12 +83,13 @@ public class PostService {
 		return PostConverter.toResponse(post, images, username);
 	}
 
-	public Page<PostDto.Response> getAllPost(Pageable pageable,
-											 Category category,
-											 Long memberId,
-											 String title,
-											 Long buyerId) {
-		return postCriteriaRepository.findAllByOffsetPaging(pageable, category, memberId, title, buyerId).map(post -> {
+	public Slice<PostDto.Response> getAllPost(Pageable pageable,
+											  Long id,
+											  Category category,
+											  Long memberId,
+											  String title,
+											  Long buyerId) {
+		return postCriteriaRepository.findAllByOffsetPaging(pageable, id, category, memberId, title, buyerId).map(post -> {
 			List<ImageDto.ImageResponse> images = imageService.getImages(DomainName.POST, post.getId());
 			String username = getUsername(post.getMemberId());
 

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostCriteriaRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostCriteriaRepository.java
@@ -8,9 +8,9 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -26,7 +26,8 @@ public class PostCriteriaRepository {
         this.entityManager = entityManager;
     }
 
-    public Page<Post> findAllByOffsetPaging(Pageable pageable,
+    public Slice<Post> findAllByOffsetPaging(Pageable pageable,
+                                            Long id,
                                             Category category,
                                             Long memberId,
                                             String title,
@@ -35,6 +36,9 @@ public class PostCriteriaRepository {
         CriteriaQuery<Post> cq = builder.createQuery(Post.class);
         Root<Post> root = cq.from(Post.class);
 
+        Predicate ltId = Optional.ofNullable(id)
+                .map(value -> builder.lessThan(root.get("id"), value))
+                .orElse(null);
         Predicate eqCategory = Optional.ofNullable(category)
                 .map(value -> builder.equal(root.get("category"), value))
                 .orElse(null);
@@ -42,25 +46,36 @@ public class PostCriteriaRepository {
                 .map(value -> builder.equal(root.get("memberId"), value))
                 .orElse(null);
         Predicate likeTitle = Optional.ofNullable(title)
-                .map(value -> builder.equal(root.get("title"), "%" + value + "%"))
+                .map(value -> builder.like(root.get("title"), "%" + value + "%"))
                 .orElse(null);
         Predicate eqBuyerId = Optional.ofNullable(buyerId)
                 .map(value -> builder.equal(root.get("buyerId"), value))
                 .orElse(null);
 
         Predicate predicate = builder.and(
-                Stream.of(eqCategory, eqMemberId, likeTitle, eqBuyerId)
+                Stream.of(ltId, eqCategory, eqMemberId, likeTitle, eqBuyerId)
                         .filter(Objects::nonNull)
                         .toArray(Predicate[]::new)
         );
 
-        cq.select(root).where(predicate);
+        cq.select(root)
+                .where(predicate)
+                .orderBy(builder.desc(root.get("id")));
 
         TypedQuery<Post> query = entityManager.createQuery(cq);
         List<Post> posts = query.setFirstResult((int) pageable.getOffset())
                 .setMaxResults(pageable.getPageSize() + 1)
                 .getResultList();
 
-        return new PageImpl<>(posts, pageable, posts.size());
+        return toSlice(pageable, posts);
+    }
+
+    private SliceImpl<Post> toSlice(Pageable pageable, List<Post> posts) {
+        if (posts.size() > pageable.getPageSize()) {
+            posts.remove(posts.size() - 1);
+            return new SliceImpl<>(posts, pageable, true);
+        }
+
+        return new SliceImpl<>(posts, pageable, false);
     }
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostCriteriaRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostCriteriaRepository.java
@@ -1,0 +1,66 @@
+package com.devcourse.be04daangnmarket.post.repository;
+
+import com.devcourse.be04daangnmarket.post.domain.Post;
+import com.devcourse.be04daangnmarket.post.domain.constant.Category;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Repository
+public class PostCriteriaRepository {
+    private final EntityManager entityManager;
+
+    public PostCriteriaRepository(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public Page<Post> findAllByOffsetPaging(Pageable pageable,
+                                            Category category,
+                                            Long memberId,
+                                            String title,
+                                            Long buyerId) {
+        CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Post> cq = builder.createQuery(Post.class);
+        Root<Post> root = cq.from(Post.class);
+
+        Predicate eqCategory = Optional.ofNullable(category)
+                .map(value -> builder.equal(root.get("category"), value))
+                .orElse(null);
+        Predicate eqMemberId = Optional.ofNullable(memberId)
+                .map(value -> builder.equal(root.get("memberId"), value))
+                .orElse(null);
+        Predicate likeTitle = Optional.ofNullable(title)
+                .map(value -> builder.equal(root.get("title"), "%" + value + "%"))
+                .orElse(null);
+        Predicate eqBuyerId = Optional.ofNullable(buyerId)
+                .map(value -> builder.equal(root.get("buyerId"), value))
+                .orElse(null);
+
+        Predicate predicate = builder.and(
+                Stream.of(eqCategory, eqMemberId, likeTitle, eqBuyerId)
+                        .filter(Objects::nonNull)
+                        .toArray(Predicate[]::new)
+        );
+
+        cq.select(root).where(predicate);
+
+        TypedQuery<Post> query = entityManager.createQuery(cq);
+        List<Post> posts = query.setFirstResult((int) pageable.getOffset())
+                .setMaxResults(pageable.getPageSize() + 1)
+                .getResultList();
+
+        return new PageImpl<>(posts, pageable, posts.size());
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,6 +11,7 @@ spring:
     hibernate:
       ddl-auto: create
       generate-ddl: true
+    show-sql: true
 
 jasypt:
   encryptor:

--- a/src/main/resources/templates/categoryPosts.html
+++ b/src/main/resources/templates/categoryPosts.html
@@ -30,7 +30,7 @@
         itemList = '';
         pagination.innerHTML = '';
 
-        axios.get(`/api/v1/posts/category?category=${category}&page=${page}`)
+        axios.get(`/api/v1/posts/search?category=${category}&page=${page}`)
             .then(res => {
                 if (res.data.content.length !== 0) {
                     res.data.content.map(post => addRow(post));

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -89,7 +89,7 @@
         itemList = '';
         pagination.innerHTML = '';
 
-        axios.get(`/api/v1/posts`, {params: {page: page}})
+        axios.get(`/api/v1/posts/search`, {params: {page: page}})
             .then(response => {
 
                 if (response.data.content.length !== 0) {

--- a/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
@@ -199,7 +199,7 @@ class PostRestControllerTest {
 		Page<PostDto.Response> responsePage = new PageImpl<>(fakeResponses, pageable, fakeResponses.size());
 
 		// when
-		when(postService.getAllPost(pageable)).thenReturn(responsePage);
+		when(postService.getAllPost(pageable, null, null, null, null)).thenReturn(responsePage);
 
 		// then
 		mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/posts")
@@ -237,7 +237,7 @@ class PostRestControllerTest {
 
 		List<PostDto.Response> mockResponses = List.of(postResponse);
 
-		when(postService.getPostByCategory(category, pageable)).thenReturn(new PageImpl<>(mockResponses));
+		when(postService.getAllPost(pageable, category, null, null, null)).thenReturn(new PageImpl<>(mockResponses));
 
 		// when then
 		mockMvc.perform(get("/api/v1/posts/category")

--- a/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
@@ -19,6 +19,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -196,10 +198,10 @@ class PostRestControllerTest {
 		List<PostDto.Response> fakeResponses = List.of(postResponse1, postResponse2);
 
 		Pageable pageable = PageRequest.of(0, 10);
-		Page<PostDto.Response> responsePage = new PageImpl<>(fakeResponses, pageable, fakeResponses.size());
+		Slice<PostDto.Response> responsePage = new SliceImpl<>(fakeResponses, pageable, false);
 
 		// when
-		when(postService.getAllPost(pageable, null, null, null, null)).thenReturn(responsePage);
+		when(postService.getAllPost(pageable, null, null, null, null, null)).thenReturn((Page<PostDto.Response>) responsePage);
 
 		// then
 		mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/posts")
@@ -237,7 +239,7 @@ class PostRestControllerTest {
 
 		List<PostDto.Response> mockResponses = List.of(postResponse);
 
-		when(postService.getAllPost(pageable, category, null, null, null)).thenReturn(new PageImpl<>(mockResponses));
+		when(postService.getAllPost(pageable, null, category, null, null, null)).thenReturn(new PageImpl<>(mockResponses));
 
 		// when then
 		mockMvc.perform(get("/api/v1/posts/category")

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.devcourse.be04daangnmarket.image.dto.ImageDto;
+import com.devcourse.be04daangnmarket.post.repository.PostCriteriaRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -44,6 +45,9 @@ class PostServiceTest {
 
 	@Mock
 	private PostRepository postRepository;
+
+	@Mock
+	private PostCriteriaRepository postCriteriaRepository;
 
 	@Mock
 	private ImageService imageService;
@@ -214,7 +218,7 @@ class PostServiceTest {
 		when(postRepository.findAll(pageable)).thenReturn(page);
 
 		// when
-		Page<PostDto.Response> response = postService.getAllPost(pageable);
+		Page<PostDto.Response> response = postService.getAllPost(pageable, null, null, null, null);
 
 		// then
 		assertEquals(page.getTotalElements(), response.getTotalElements());
@@ -239,10 +243,10 @@ class PostServiceTest {
 		List<Post> posts = List.of(post);
 		Pageable pageable = PageRequest.of(0, 10);
 		Page<Post> page = new PageImpl<>(posts);
-		when(postRepository.findByCategory(category, pageable)).thenReturn(page);
+		when(postCriteriaRepository.findAllByOffsetPaging(pageable, category, null, null, null)).thenReturn(page);
 
 		// when
-		Page<PostDto.Response> response = postService.getPostByCategory(category, pageable);
+		Page<PostDto.Response> response = postService.getAllPost(pageable, category, null, null, null);
 
 		// then
 		assertEquals(page.getTotalElements(), response.getTotalElements());
@@ -267,10 +271,10 @@ class PostServiceTest {
 		List<Post> posts = List.of(post);
 		Pageable pageable = PageRequest.of(0, 10);
 		Page<Post> page = new PageImpl<>(posts);
-		when(postRepository.findByMemberId(memberId, pageable)).thenReturn(page);
+		when(postCriteriaRepository.findAllByOffsetPaging(pageable, null, memberId, null, null)).thenReturn(page);
 
 		// when
-		Page<PostDto.Response> response = postService.getPostByMemberId(memberId, pageable);
+		Page<PostDto.Response> response = postService.getAllPost(pageable, null, memberId, null, null);
 
 		// then
 		assertEquals(page.getTotalElements(), response.getTotalElements());

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -20,6 +20,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -214,14 +216,14 @@ class PostServiceTest {
 
 		List<Post> posts = List.of(post, post2);
 		Pageable pageable = PageRequest.of(0, 10);
-		Page<Post> page = new PageImpl<>(posts, pageable, posts.size());
-		when(postRepository.findAll(pageable)).thenReturn(page);
+		Slice<Post> page = new SliceImpl<>(posts, pageable, false);
+		when(postCriteriaRepository.findAllByOffsetPaging(pageable, null, null, null, null, null)).thenReturn(page);
 
 		// when
-		Page<PostDto.Response> response = postService.getAllPost(pageable, null, null, null, null);
+		Slice<PostDto.Response> response = postService.getAllPost(pageable, null, null, null, null, null);
 
 		// then
-		assertEquals(page.getTotalElements(), response.getTotalElements());
+		assertEquals(page.hasNext(), response.hasNext());
 		assertEquals(page.getNumber(), response.getNumber());
 		verify(postRepository, times(1)).findAll(pageable);
 	}
@@ -242,14 +244,14 @@ class PostServiceTest {
 
 		List<Post> posts = List.of(post);
 		Pageable pageable = PageRequest.of(0, 10);
-		Page<Post> page = new PageImpl<>(posts);
-		when(postCriteriaRepository.findAllByOffsetPaging(pageable, category, null, null, null)).thenReturn(page);
+		Slice<Post> page = new SliceImpl<>(posts, pageable, false);
+		when(postCriteriaRepository.findAllByOffsetPaging(pageable, null, category, null, null, null)).thenReturn(page);
 
 		// when
-		Page<PostDto.Response> response = postService.getAllPost(pageable, category, null, null, null);
+		Slice<PostDto.Response> response = postService.getAllPost(pageable, null, null, null, null, null);
 
 		// then
-		assertEquals(page.getTotalElements(), response.getTotalElements());
+		assertEquals(page.hasNext(), response.hasNext());
 		assertEquals(page.getNumber(), response.getNumber());
 		verify(postRepository, times(1)).findByCategory(category, pageable);
 	}
@@ -270,14 +272,14 @@ class PostServiceTest {
 
 		List<Post> posts = List.of(post);
 		Pageable pageable = PageRequest.of(0, 10);
-		Page<Post> page = new PageImpl<>(posts);
-		when(postCriteriaRepository.findAllByOffsetPaging(pageable, null, memberId, null, null)).thenReturn(page);
+		Slice<Post> page = new SliceImpl<>(posts, pageable, false);
+		when(postCriteriaRepository.findAllByOffsetPaging(pageable, null, null, null, null, null)).thenReturn(page);
 
 		// when
-		Page<PostDto.Response> response = postService.getAllPost(pageable, null, memberId, null, null);
+		Slice<PostDto.Response> response = postService.getAllPost(pageable, null, null, null, null, null);
 
 		// then
-		assertEquals(page.getTotalElements(), response.getTotalElements());
+		assertEquals(page.hasNext(), response.hasNext());
 		assertEquals(page.getNumber(), response.getNumber());
 		verify(postRepository, times(1)).findByMemberId(memberId, pageable);
 	}


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
기존에 카테고리, 게시글, 멤버Id, 검색를 통해서 각각의 다른 API를 통해 조회하던 방식을 동적 쿼리를 사용하여 하나의 API로 통합하였습니다.
기존 offset방식에서 cursor 방식으로 수정하는 작업을 수행하였습니다.

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] 동적쿼리를 사용하여 검색 API를 하나로 통합하다
- [x] 커서 페이징네이션을 구현하다
