### PR TITLE
[KIM-212] 커서 기반 조회 및 다중 필터 조회 메서드 수정 

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/common/entity/BaseEntity.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/entity/BaseEntity.java
@@ -1,6 +1,7 @@
 package com.devcourse.be04daangnmarket.common.entity;
 
 import java.time.LocalDateTime;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -14,27 +15,27 @@ import jakarta.persistence.MappedSuperclass;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@CreatedDate
-	@Column(nullable = false, updatable = false, columnDefinition = "TIMESTAMP")
-	private LocalDateTime createdAt;
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
-	@LastModifiedDate
-	@Column(nullable = false, columnDefinition = "TIMESTAMP")
-	private LocalDateTime updatedAt;
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
 
-	public Long getId() {
-		return id;
-	}
+    public Long getId() {
+        return id;
+    }
 
-	public LocalDateTime getCreatedAt() {
-		return createdAt;
-	}
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
 
-	public LocalDateTime getUpdatedAt() {
-		return updatedAt;
-	}
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -75,9 +75,9 @@ public class PostRestController {
     }
 
     @GetMapping("/filter")
-    public ResponseEntity<Slice<PostDto.Response>> getPostsWithFilters(PostDto.FilterRequest request,
-                                                                       Pageable pageable) {
-        Slice<PostDto.Response> responses = postService.getPostsWithFilter(request, pageable);
+    public ResponseEntity<Slice<PostDto.Response>> getPostsWithCursorWithFilters(PostDto.FilterRequest request,
+                                                                                 Pageable pageable) {
+        Slice<PostDto.Response> responses = postService.getPostsWithCursorWithFilters(request, pageable);
 
         return ResponseEntity.ok(responses);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.*;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -76,7 +77,7 @@ public class PostRestController {
 
     @GetMapping("/filter")
     public ResponseEntity<Slice<PostDto.Response>> getPostsWithCursorWithFilters(PostDto.FilterRequest request,
-                                                                                 Pageable pageable) {
+                                                                                 @PageableDefault(sort = "price", direction = Sort.Direction.DESC) Pageable pageable) {
         Slice<PostDto.Response> responses = postService.getPostsWithCursorWithFilters(request, pageable);
 
         return ResponseEntity.ok(responses);

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -92,7 +92,7 @@ public class PostService {
     }
 
     public Slice<PostDto.Response> getPostsWithCursorWithFilters(PostDto.FilterRequest request, Pageable pageable) {
-        return postRepository.getPostsWithCursorWithFilers(
+        return postRepository.findPostsWithCursorWithFilters(
                         request.id(),
                         request.createdAt(),
                         request.category(),

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -91,9 +91,10 @@ public class PostService {
         });
     }
 
-    public Slice<PostDto.Response> getPostsWithFilter(PostDto.FilterRequest request, Pageable pageable) {
-        return postRepository.getPostsWithMultiFilters(
+    public Slice<PostDto.Response> getPostsWithCursorWithFilters(PostDto.FilterRequest request, Pageable pageable) {
+        return postRepository.getPostsWithCursorWithFilers(
                         request.id(),
+                        request.createdAt(),
                         request.category(),
                         request.memberId(),
                         request.buyerId(),

--- a/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/dto/PostDto.java
@@ -67,6 +67,8 @@ public class PostDto {
     public record FilterRequest(
             Long id,
 
+            LocalDateTime createdAt,
+
             Category category,
 
             Long memberId,

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepository.java
@@ -9,7 +9,7 @@ import com.devcourse.be04daangnmarket.post.domain.constant.Category;
 import com.devcourse.be04daangnmarket.post.domain.Post;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
+public interface PostRepository extends JpaRepository<Post, Long>, PostWithCursorRepository {
     Page<Post> findByCategory(Category category, Pageable pageable);
 
     Page<Post> findByMemberId(Long memberId, Pageable pageable);

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustom.java
@@ -9,13 +9,13 @@ import java.time.LocalDateTime;
 
 public interface PostRepositoryCustom {
 
-    Slice<Post> getPostsWithMultiFilters(Long id,
-                                         Category category,
-                                         Long memberId,
-                                         Long buyerId,
-                                         String keyword,
-                                         Pageable pageable
-    );
+    public Slice<Post> getPostsWithCursorWithFilers(Long id,
+                                                    LocalDateTime createdAt,
+                                                    Category category,
+                                                    Long memberId,
+                                                    Long buyerId,
+                                                    String keyword,
+                                                    Pageable pageable);
 
     Slice<Post> getPostsWithCursor(Long id,
                                    LocalDateTime createdAt,

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustom.java
@@ -5,6 +5,8 @@ import com.devcourse.be04daangnmarket.post.domain.constant.Category;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.time.LocalDateTime;
+
 public interface PostRepositoryCustom {
 
     Slice<Post> getPostsWithMultiFilters(Long id,
@@ -15,5 +17,7 @@ public interface PostRepositoryCustom {
                                          Pageable pageable
     );
 
-    Slice<Post> getPostsWithCursor(Long id, Pageable pageable);
+    Slice<Post> getPostsWithCursor(Long id,
+                                   LocalDateTime createdAt,
+                                   Pageable pageable);
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustom.java
@@ -14,4 +14,6 @@ public interface PostRepositoryCustom {
                                          String keyword,
                                          Pageable pageable
     );
+
+    Slice<Post> getPostsWithCursor(Long id, Pageable pageable);
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustomImpl.java
@@ -86,34 +86,16 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
 
         Predicate cursorRestriction = Optional.ofNullable(createdAt)
                 .map(key -> {
-                    Predicate where = switch (createdAtSort.getOrderFor("createdAt").getDirection()) {
-                        case DESC -> {
-                            Predicate createdAtLt = builder.lessThan(post.get("createdAt"), key);
+                    Predicate createdAtEq = builder.equal(post.get("createdAt"), key);
+                    Predicate idLt = builder.lessThan(post.get("id"), id);
 
-                            Predicate createdAtEq = builder.equal(post.get("createdAt"), key);
-                            Predicate idLt = builder.lessThan(post.get("id"), id);
+                    Predicate and = builder.and(createdAtEq, idLt);
 
-                            Predicate and = builder.and(createdAtEq, idLt);
-                            Predicate or = builder.or(createdAtLt, and);
-
-                            yield or;
-                        }
-                        case ASC -> {
-                            Predicate createdAtGt = builder.greaterThan(post.get("createdAt"), key);
-
-                            Predicate createdAtEq = builder.equal(post.get("createdAt"), key);
-                            Predicate idLt = builder.lessThan(post.get("id"), id);
-
-                            Predicate and = builder.and(createdAtEq, idLt);
-                            Predicate or = builder.or(createdAtGt, and);
-
-                            yield or;
-                        }
-                    };
-
-                    return where;
+                    return createdAtSort.getOrderFor("createdAt").isDescending()
+                            ? builder.or(builder.lessThan(post.get("createdAt"), key), and)
+                            : builder.or(builder.greaterThan(post.get("createdAt"), key), and);
                 })
-                .orElseGet(() -> null);
+                .orElse(null);
 
         Predicate[] where = Stream.of(cursorRestriction).filter(Objects::nonNull).toArray(Predicate[]::new);
 

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostWithCursorRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostWithCursorRepository.java
@@ -7,9 +7,9 @@ import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
 
-public interface PostRepositoryCustom {
+public interface PostWithCursorRepository {
 
-    public Slice<Post> getPostsWithCursorWithFilers(Long id,
+    public Slice<Post> findPostsWithCursorWithFilters(Long id,
                                                     LocalDateTime createdAt,
                                                     Category category,
                                                     Long memberId,
@@ -17,7 +17,7 @@ public interface PostRepositoryCustom {
                                                     String keyword,
                                                     Pageable pageable);
 
-    Slice<Post> getPostsWithCursor(Long id,
+    Slice<Post> findPostsWithCursor(Long id,
                                    LocalDateTime createdAt,
                                    Pageable pageable);
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostWithCursorRepositoryImpl.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostWithCursorRepositoryImpl.java
@@ -5,27 +5,34 @@ import com.devcourse.be04daangnmarket.post.domain.constant.Category;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.*;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
 
 import java.time.LocalDateTime;
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
-public class PostRepositoryCustomImpl implements PostRepositoryCustom {
+public class PostWithCursorRepositoryImpl implements PostWithCursorRepository {
     private final EntityManager em;
 
-    public PostRepositoryCustomImpl(EntityManager em) {
+    public PostWithCursorRepositoryImpl(EntityManager em) {
         this.em = em;
     }
 
     @Override
-    public Slice<Post> getPostsWithCursorWithFilers(Long id,
-                                                    LocalDateTime createdAt,
-                                                    Category category,
-                                                    Long memberId,
-                                                    Long buyerId,
-                                                    String keyword,
-                                                    Pageable pageable) {
+    public Slice<Post> findPostsWithCursorWithFilters(Long id,
+                                                      LocalDateTime createdAt,
+                                                      Category category,
+                                                      Long memberId,
+                                                      Long buyerId,
+                                                      String keyword,
+                                                      Pageable pageable) {
 
         Sort createdAtSort = pageable.getSortOr(Sort.by(Sort.Direction.DESC, "createdAt"));
 
@@ -77,9 +84,9 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public Slice<Post> getPostsWithCursor(Long id,
-                                          LocalDateTime createdAt,
-                                          Pageable pageable) {
+    public Slice<Post> findPostsWithCursor(Long id,
+                                           LocalDateTime createdAt,
+                                           Pageable pageable) {
         CriteriaBuilder builder = em.getCriteriaBuilder();
         CriteriaQuery<Post> query = builder.createQuery(Post.class);
         Root<Post> post = query.from(Post.class);

--- a/src/test/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustomImplTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustomImplTest.java
@@ -209,4 +209,61 @@ class PostRepositoryCustomImplTest {
         assertEquals(1L, selectedPost.getContent().get(0).getId());
         assertEquals(1, selectedPost.getContent().size());
     }
+
+    @Test
+    @DisplayName("정렬 조건 없는 커서 기반 페이징 첫 조회 성공")
+    void getPostsByCursor() {
+        // given
+        List<Post> posts = List.of(
+                new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+                        Category.DIGITAL_DEVICES),
+                new Post(1L, "mouse~!", "this keyboard is good", 100000, TransactionType.SALE,
+                        Category.DIGITAL_DEVICES),
+                new Post(1L, "keyKey~!", "this keyboard is good", 100000, TransactionType.SALE,
+                        Category.HOUSEHOLD_KITCHEN),
+                new Post(1L, "house~!", "this keyboard is good", 100000, TransactionType.SALE,
+                        Category.DIGITAL_DEVICES)
+        );
+        postRepository.saveAll(posts);
+
+        // when
+        Pageable pageable = PageRequest.of(0, 2);
+        Slice<Post> selectedPost = postRepository.getPostsWithCursor(
+                null,
+                pageable
+        );
+
+        // then
+        assertEquals(4L, selectedPost.getContent().get(0).getId());
+        assertEquals(2, selectedPost.getContent().size());
+    }
+
+    @Test
+    @DisplayName("정렬 조건 없는 커서 기반 페이징 첫 번째 이후 조회 성공")
+    void getPostsByCursor2() {
+        // given
+        List<Post> posts = List.of(
+                new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+                        Category.DIGITAL_DEVICES),
+                new Post(1L, "mouse~!", "this keyboard is good", 100000, TransactionType.SALE,
+                        Category.DIGITAL_DEVICES),
+                new Post(1L, "keyKey~!", "this keyboard is good", 100000, TransactionType.SALE,
+                        Category.HOUSEHOLD_KITCHEN),
+                new Post(1L, "house~!", "this keyboard is good", 100000, TransactionType.SALE,
+                        Category.DIGITAL_DEVICES)
+        );
+        postRepository.saveAll(posts);
+
+        // when
+        Pageable pageable = PageRequest.of(0, 2);
+        Slice<Post> selectedPost = postRepository.getPostsWithCursor(
+                2L,
+                pageable
+        );
+
+        // then
+        assertEquals(1L, selectedPost.getContent().get(0).getId());
+        assertEquals(1, selectedPost.getContent().size());
+    }
+
 }

--- a/src/test/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustomImplTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustomImplTest.java
@@ -11,8 +11,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -211,59 +213,80 @@ class PostRepositoryCustomImplTest {
     }
 
     @Test
-    @DisplayName("정렬 조건 없는 커서 기반 페이징 첫 조회 성공")
-    void getPostsByCursor() {
+    @DisplayName("생성 시간에 대한 커서 기반 페이징 첫 조회 성공")
+    void getPostsByCursorWithFirstTest() {
         // given
         List<Post> posts = List.of(
                 new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
                         Category.DIGITAL_DEVICES),
-                new Post(1L, "mouse~!", "this keyboard is good", 100000, TransactionType.SALE,
+                new Post(1L, "mouse~!", "this keyboard is good", 200000, TransactionType.SALE,
                         Category.DIGITAL_DEVICES),
-                new Post(1L, "keyKey~!", "this keyboard is good", 100000, TransactionType.SALE,
+                new Post(1L, "keyKey~!", "this keyboard is good", 200000, TransactionType.SALE,
                         Category.HOUSEHOLD_KITCHEN),
-                new Post(1L, "house~!", "this keyboard is good", 100000, TransactionType.SALE,
+                new Post(1L, "house~!", "this keyboard is good", 300000, TransactionType.SALE,
                         Category.DIGITAL_DEVICES)
         );
         postRepository.saveAll(posts);
 
         // when
-        Pageable pageable = PageRequest.of(0, 2);
-        Slice<Post> selectedPost = postRepository.getPostsWithCursor(
-                null,
-                pageable
-        );
+        PageRequest pageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Slice<Post> pageResult = postRepository.getPostsWithCursor(null, null, pageable);
 
         // then
-        assertEquals(4L, selectedPost.getContent().get(0).getId());
-        assertEquals(2, selectedPost.getContent().size());
+        assertEquals(4L, pageResult.getContent().get(0).getId());
+        assertEquals(2, pageResult.getContent().size());
     }
 
     @Test
-    @DisplayName("정렬 조건 없는 커서 기반 페이징 첫 번째 이후 조회 성공")
-    void getPostsByCursor2() {
+    @DisplayName("생성 시간에 대한 커서 기반 페이징 첫 번째 이후 조회 성공")
+    void getPostsByCursorTest() {
         // given
         List<Post> posts = List.of(
                 new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
                         Category.DIGITAL_DEVICES),
-                new Post(1L, "mouse~!", "this keyboard is good", 100000, TransactionType.SALE,
+                new Post(1L, "mouse~!", "this keyboard is good", 200000, TransactionType.SALE,
                         Category.DIGITAL_DEVICES),
-                new Post(1L, "keyKey~!", "this keyboard is good", 100000, TransactionType.SALE,
+                new Post(1L, "keyKey~!", "this keyboard is good", 200000, TransactionType.SALE,
                         Category.HOUSEHOLD_KITCHEN),
-                new Post(1L, "house~!", "this keyboard is good", 100000, TransactionType.SALE,
+                new Post(1L, "house~!", "this keyboard is good", 300000, TransactionType.SALE,
                         Category.DIGITAL_DEVICES)
         );
         postRepository.saveAll(posts);
 
         // when
-        Pageable pageable = PageRequest.of(0, 2);
-        Slice<Post> selectedPost = postRepository.getPostsWithCursor(
-                2L,
-                pageable
-        );
+        Post selectedPost = postRepository.findById(3L).get();
+        PageRequest pageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Slice<Post> pageResult = postRepository.getPostsWithCursor(3L, selectedPost.getCreatedAt(), pageable);
 
         // then
-        assertEquals(1L, selectedPost.getContent().get(0).getId());
-        assertEquals(1, selectedPost.getContent().size());
+        assertEquals(2L, pageResult.getContent().get(0).getId());
+        assertEquals(2, pageResult.getContent().size());
+    }
+
+    @Test
+    @DisplayName("생성 시간에 대한 오름차순 커서 기반 페이징 조회 성공")
+    void PostRepositoryCustomImplTest() {
+        // given
+        List<Post> posts = List.of(
+                new Post(1L, "keyboard~!", "this keyboard is good", 100000, TransactionType.SALE,
+                        Category.DIGITAL_DEVICES),
+                new Post(1L, "mouse~!", "this keyboard is good", 200000, TransactionType.SALE,
+                        Category.DIGITAL_DEVICES),
+                new Post(1L, "keyKey~!", "this keyboard is good", 200000, TransactionType.SALE,
+                        Category.HOUSEHOLD_KITCHEN),
+                new Post(1L, "house~!", "this keyboard is good", 300000, TransactionType.SALE,
+                        Category.DIGITAL_DEVICES)
+        );
+
+        postRepository.saveAll(posts);
+
+        // when
+        PageRequest pageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "createdAt"));
+        Slice<Post> pageResult = postRepository.getPostsWithCursor(null, null, pageable);
+
+        // then
+        assertEquals(1L, pageResult.getContent().get(0).getId());
+        assertEquals(2, pageResult.getContent().size());
     }
 
 }

--- a/src/test/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustomImplTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryCustomImplTest.java
@@ -42,7 +42,8 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 10);
-        Slice<Post> selectedPost = postRepository.getPostsWithMultiFilters(
+        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+                null,
                 null,
                 Category.DIGITAL_DEVICES,
                 null,
@@ -73,7 +74,8 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 10);
-        Slice<Post> selectedPost = postRepository.getPostsWithMultiFilters(
+        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+                null,
                 null,
                 null,
                 null,
@@ -104,7 +106,8 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 10);
-        Slice<Post> selectedPost = postRepository.getPostsWithMultiFilters(
+        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+                null,
                 null,
                 Category.DIGITAL_DEVICES,
                 2L,
@@ -135,7 +138,8 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 10);
-        Slice<Post> selectedPost = postRepository.getPostsWithMultiFilters(
+        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+                null,
                 null,
                 null,
                 null,
@@ -166,7 +170,8 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 2);
-        Slice<Post> selectedPost = postRepository.getPostsWithMultiFilters(
+        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+                null,
                 null,
                 null,
                 null,
@@ -198,8 +203,9 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 2);
-        Slice<Post> selectedPost = postRepository.getPostsWithMultiFilters(
+        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
                 2L,
+                null,
                 null,
                 null,
                 null,

--- a/src/test/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/repository/PostRepositoryTest.java
@@ -7,16 +7,16 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 
 import com.devcourse.be04daangnmarket.post.domain.constant.Category;
 import com.devcourse.be04daangnmarket.post.domain.Post;
 import com.devcourse.be04daangnmarket.post.domain.constant.TransactionType;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class PostRepositoryTest {
 	@Autowired
 	private PostRepository postRepository;
@@ -42,6 +42,6 @@ class PostRepositoryTest {
 		Page<Post> selectedPost = postRepository.findByTitleContaining("key", pageable);
 
 		// then
-		assertEquals(2, selectedPost.getTotalPages());
+		assertEquals(2, selectedPost.getNumberOfElements());
 	}
 }

--- a/src/test/java/com/devcourse/be04daangnmarket/post/repository/PostWithCursorRepositoryImplTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/repository/PostWithCursorRepositoryImplTest.java
@@ -14,13 +14,12 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-class PostRepositoryCustomImplTest {
+class PostWithCursorRepositoryImplTest {
     @Autowired
     private PostRepository postRepository;
 
@@ -42,7 +41,7 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 10);
-        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+        Slice<Post> selectedPost = postRepository.findPostsWithCursorWithFilters(
                 null,
                 null,
                 Category.DIGITAL_DEVICES,
@@ -74,7 +73,7 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 10);
-        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+        Slice<Post> selectedPost = postRepository.findPostsWithCursorWithFilters(
                 null,
                 null,
                 null,
@@ -106,7 +105,7 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 10);
-        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+        Slice<Post> selectedPost = postRepository.findPostsWithCursorWithFilters(
                 null,
                 null,
                 Category.DIGITAL_DEVICES,
@@ -138,7 +137,7 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 10);
-        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+        Slice<Post> selectedPost = postRepository.findPostsWithCursorWithFilters(
                 null,
                 null,
                 null,
@@ -170,7 +169,7 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 2);
-        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+        Slice<Post> selectedPost = postRepository.findPostsWithCursorWithFilters(
                 null,
                 null,
                 null,
@@ -203,7 +202,7 @@ class PostRepositoryCustomImplTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 2);
-        Slice<Post> selectedPost = postRepository.getPostsWithCursorWithFilers(
+        Slice<Post> selectedPost = postRepository.findPostsWithCursorWithFilters(
                 2L,
                 null,
                 null,
@@ -236,7 +235,7 @@ class PostRepositoryCustomImplTest {
 
         // when
         PageRequest pageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Slice<Post> pageResult = postRepository.getPostsWithCursor(null, null, pageable);
+        Slice<Post> pageResult = postRepository.findPostsWithCursor(null, null, pageable);
 
         // then
         assertEquals(4L, pageResult.getContent().get(0).getId());
@@ -262,7 +261,7 @@ class PostRepositoryCustomImplTest {
         // when
         Post selectedPost = postRepository.findById(3L).get();
         PageRequest pageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Slice<Post> pageResult = postRepository.getPostsWithCursor(3L, selectedPost.getCreatedAt(), pageable);
+        Slice<Post> pageResult = postRepository.findPostsWithCursor(3L, selectedPost.getCreatedAt(), pageable);
 
         // then
         assertEquals(2L, pageResult.getContent().get(0).getId());
@@ -288,7 +287,7 @@ class PostRepositoryCustomImplTest {
 
         // when
         PageRequest pageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "createdAt"));
-        Slice<Post> pageResult = postRepository.getPostsWithCursor(null, null, pageable);
+        Slice<Post> pageResult = postRepository.findPostsWithCursor(null, null, pageable);
 
         // then
         assertEquals(1L, pageResult.getContent().get(0).getId());


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 기존 동적쿼리 기반으로 커서 페이징 및 다중 필터 조회 메서드를 수정했습니다.

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] 조건 없는 커서 페이징 조회 메서드 생성 
- [x] 페이징 조회 메서드에 생성 시간 조건 및 정렬 순서를 반영하도록 개선 
- [x] 페이징 조회 메서드 중복되는 코드 개선 
- [x] 다중 필터 조회 메서드 개선  

### 🐰 PR POINT  <!-- PR에서 중점적으로 봐야할 부문을 작성해주세요. -->
- 기존 중복되는 코드를 개선했습니다.
- 고유값이 아닌 컬럼 (생성일시) 조건에 대해 커서 페이징이 되도록 구현했습니다.
- 해당 컬럼에 대해 오름차순, 내림차순을 반영하도록 했습니다. 

### 🥕 리뷰어에게 하고싶은 말  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 하고 싶은 부분이 많았지만 개인역량과 상황을 고려해 최소한의 요건만 반영했습니다. 이해자체와 접근이 잘못 된 것 같기도 해서 잠시 멈췄습니다.
- 생각해봤던 포인트를 공유합니다. 

  1. 당근마켓 검색 조회 결과 시 최신순, 정확도 순과 같은 정렬 조건에 대해 동적으로 커서페이징을 제공하고자했습니다. 
     선택 여부에 대해 어떻게 동적으로 반영할 수 있을까 고민해봤습니다. 

  2. 정렬 조건이 다수일때, 예를 들어 최신순 - 가격순 일때 동적으로 변경되도록 하고싶었습니다. 
      나아가 조건의 개수 제한없이 반영하도록 구성하고 싶었습니다.
      쿼리 자체의 규칙은 찾았지만 이를 애플리케이션에서 구성하는데 무리가 있었습니다. 분석이 좀 더 필요하다고 생각합니다. 

- 현재 다중필터, 커서 페이징에 대한 메서드가 있습니다. 둘 차이는 다중필터 반영여부를 제외하고 동일합니다. 하나로 통일할 수 있었지만
   다중 필터는 검색조회를 위한 api, 커서 페이징은 확장을 위해 남겨둔 상태입니다. 

- 다중필터로 대체할 수 있는 모든 api를 삭제하려 했으나 api마다 식별할 수 있는 uri가 있고 대체가 삭제의 기준이 되지 않는다고 생각해서 남겨두었습니다. 
 