### PR TITLE
[KIM-224] 게시글 조회수 로직 동시성 제어 반영

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/application/CommentService.java
@@ -9,6 +9,7 @@ import com.devcourse.be04daangnmarket.comment.repository.CommentRepository;
 import com.devcourse.be04daangnmarket.comment.util.CommentConverter;
 import com.devcourse.be04daangnmarket.member.application.ProfileService;
 import com.devcourse.be04daangnmarket.member.domain.Profile;
+import com.devcourse.be04daangnmarket.member.dto.MemberDto;
 import com.devcourse.be04daangnmarket.member.dto.ProfileDto;
 import com.devcourse.be04daangnmarket.member.util.ProfileConverter;
 import com.devcourse.be04daangnmarket.post.application.PostService;
@@ -172,7 +173,7 @@ public class CommentService implements CommentProviderService {
         return toResponse(comment, imagePaths, username);
     }
 
-    public Page<MemberDto.Response> getCommenterByPostId(Long postId, Pageable pageable) {
+    public Page<ProfileDto.Response> getCommenterByPostId(Long postId, Pageable pageable) {
         Long writerId = postService.findPostById(postId).getMemberId();
 
          return commentRepository.findDistinctMemberIdsByPostIdAndNotInWriterId(postId, writerId, pageable)

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -163,7 +163,7 @@ public class PostRestController {
 
     @GetMapping("/{id}/communicationMembers")
     public ResponseEntity<Page<ProfileDto.Response>> getCommunicationMembers(@PathVariable Long id,
-                                                                            @RequestParam(defaultValue = "0") int page) {
+                                                                             @RequestParam(defaultValue = "0") int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
         Long writerId = postService.findPostById(id).getMemberId();
         Page<ProfileDto.Response> responses = commentService.getCommenterByPostId(writerId, pageable);

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import com.devcourse.be04daangnmarket.image.dto.ImageDto;
+import com.devcourse.be04daangnmarket.common.image.dto.ImageDto;
 import com.devcourse.be04daangnmarket.member.application.ProfileService;
 import com.devcourse.be04daangnmarket.post.domain.constant.PostStatus;
 import com.devcourse.be04daangnmarket.post.util.PostConverter;
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.devcourse.be04daangnmarket.image.application.ImageService;
 import com.devcourse.be04daangnmarket.image.domain.constant.DomainName;
-import com.devcourse.be04daangnmarket.member.application.MemberService;
 import com.devcourse.be04daangnmarket.post.domain.constant.Category;
 import com.devcourse.be04daangnmarket.post.domain.Post;
 import com.devcourse.be04daangnmarket.post.domain.constant.TransactionType;
@@ -70,12 +69,12 @@ public class PostService {
 
     @Transactional
     public PostDto.Response getPost(Long id, HttpServletRequest req, HttpServletResponse res) {
-        Post post = findPostById(id);
+        Post post = postRepository.findByIdForUpdate(id).
+                orElseThrow(() -> new NoSuchElementException(NOT_FOUND_POST.getMessage()));
 
         if (!isViewed(id, req, res)) {
             post.updateView();
         }
-
 
         List<String> imagePaths = imageService.getImages(DomainName.POST, id);
         String username = getUsername(post.getMemberId());

--- a/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepository.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/repository/PostRepository.java
@@ -1,12 +1,17 @@
 package com.devcourse.be04daangnmarket.post.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.devcourse.be04daangnmarket.post.domain.constant.Category;
 import com.devcourse.be04daangnmarket.post.domain.Post;
+
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long>, PostWithCursorRepository {
@@ -17,4 +22,8 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostWithCurso
     Page<Post> findByTitleContaining(String title, Pageable pageable);
 
     Page<Post> findByBuyerId(Long buyerId, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Post p WHERE p.id = :id")
+    Optional<Post> findByIdForUpdate(Long id);
 }


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 게시글 조회 수 증가 로직이 동시성을 제어하도록 했습니다. 

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] 게시글 조회수가 동시성을 반영하도록 수정

### 🐰 PR POINT  <!-- PR에서 중점적으로 봐야할 부문을 작성해주세요. -->
- 다양한 방법중 트랜젝션 격리레벨을  Default로 유지하고 비관적 락을 반영한 쿼리를 사용해 동시성을 제어했습니다.
- 구현방법은 JPA에서 제공하는 애너테이션을 사용해 구현했습니다.

### 🥕 리뷰어에게 하고싶은 말  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 동시성에 대한 테스트는 JMeter를 사용해  진행했습니다.
