### PR TITLE
[KIM-229] Redis 적용 및 조회수 중복방지 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,9 @@ repositories {
 }
 
 dependencies {
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // Bean Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/infra/mysql_container/docker-compose.yml
+++ b/infra/mysql_container/docker-compose.yml
@@ -25,3 +25,13 @@ services:
       - MYSQL_PASSWORD=password
     platform: linux/arm64/v8
     restart: always
+
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - 6379:6379
+    volumes:
+      - data:/data
+    restart: always
+    platform: linux/arm64/v8

--- a/infra/mysql_container/remove
+++ b/infra/mysql_container/remove
@@ -5,3 +5,6 @@ docker rmi mysql:latest
 
 docker volume rm mysql_container_config
 docker volume rm mysql_container_data
+
+docker rm redis
+docker rmi redis:latest

--- a/infra/mysql_container/start
+++ b/infra/mysql_container/start
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
 
 docker start mysql
+docker start redis

--- a/infra/mysql_container/stop
+++ b/infra/mysql_container/stop
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
 
 docker stop mysql
+docker stop redis

--- a/src/main/java/com/devcourse/be04daangnmarket/common/config/RedisConfig.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.devcourse.be04daangnmarket.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.cache.redis.host}")
+    private String host;
+
+    @Value("${spring.cache.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -61,9 +61,8 @@ public class PostRestController {
 
     @GetMapping("/{id}")
     public ResponseEntity<PostDto.Response> getPost(@PathVariable @NotNull Long id,
-                                                    HttpServletRequest req,
-                                                    HttpServletResponse res) {
-        PostDto.Response response = postService.getPost(id, req, res);
+                                                    @AuthenticationPrincipal User user) {
+        PostDto.Response response = postService.getPost(id, user.getId());
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/application/PostService.java
@@ -1,34 +1,30 @@
 package com.devcourse.be04daangnmarket.post.application;
 
-import static com.devcourse.be04daangnmarket.post.exception.ErrorMessage.*;
+import com.devcourse.be04daangnmarket.common.image.dto.ImageDto;
+import com.devcourse.be04daangnmarket.image.application.ImageService;
+import com.devcourse.be04daangnmarket.image.domain.constant.DomainName;
+import com.devcourse.be04daangnmarket.member.application.ProfileService;
+import com.devcourse.be04daangnmarket.post.domain.Post;
+import com.devcourse.be04daangnmarket.post.domain.constant.Category;
+import com.devcourse.be04daangnmarket.post.domain.constant.PostStatus;
+import com.devcourse.be04daangnmarket.post.domain.constant.TransactionType;
+import com.devcourse.be04daangnmarket.post.dto.PostDto;
+import com.devcourse.be04daangnmarket.post.repository.PostRepository;
+import com.devcourse.be04daangnmarket.post.util.PostConverter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
-import com.devcourse.be04daangnmarket.image.dto.ImageDto;
-import com.devcourse.be04daangnmarket.member.application.ProfileService;
-import com.devcourse.be04daangnmarket.post.domain.constant.PostStatus;
-import com.devcourse.be04daangnmarket.post.util.PostConverter;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.devcourse.be04daangnmarket.image.application.ImageService;
-import com.devcourse.be04daangnmarket.image.domain.constant.DomainName;
-import com.devcourse.be04daangnmarket.member.application.MemberService;
-import com.devcourse.be04daangnmarket.post.domain.constant.Category;
-import com.devcourse.be04daangnmarket.post.domain.Post;
-import com.devcourse.be04daangnmarket.post.domain.constant.TransactionType;
-import com.devcourse.be04daangnmarket.post.dto.PostDto;
-import com.devcourse.be04daangnmarket.post.repository.PostRepository;
-
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import static com.devcourse.be04daangnmarket.post.exception.ErrorMessage.NOT_FOUND_POST;
 
 @Service
 @Transactional(readOnly = true)
@@ -36,11 +32,13 @@ public class PostService {
     private final PostRepository postRepository;
     private final ImageService imageService;
     private final ProfileService profileService;
+    private final RedisTemplate<String, String> redisTemplate;
 
-    public PostService(PostRepository postRepository, ImageService imageService, ProfileService profileService) {
+    public PostService(PostRepository postRepository, ImageService imageService, ProfileService profileService, RedisTemplate<String, String> redisTemplate) {
         this.postRepository = postRepository;
         this.imageService = imageService;
         this.profileService = profileService;
+        this.redisTemplate = redisTemplate;
     }
 
     @Transactional
@@ -69,15 +67,14 @@ public class PostService {
     }
 
     @Transactional
-    public PostDto.Response getPost(Long id, HttpServletRequest req, HttpServletResponse res) {
-        Post post = findPostById(id);
+    public PostDto.Response getPost(Long postId, Long userId) {
+        Post post = findPostById(postId);
 
-        if (!isViewed(id, req, res)) {
+        if (!isViewed(postId, userId)) {
             post.updateView();
         }
 
-
-        List<String> imagePaths = imageService.getImages(DomainName.POST, id);
+        List<String> imagePaths = imageService.getImages(DomainName.POST, postId);
         String username = getUsername(post.getMemberId());
 
         return PostConverter.toResponse(post, imagePaths, username);
@@ -206,26 +203,20 @@ public class PostService {
         return profileService.toProfile(memberId).username();
     }
 
-    private boolean isViewed(Long id, HttpServletRequest req, HttpServletResponse res) {
-        String cookieName = Long.toString(id);
-        String cookieValue = Long.toString(id);
-        Cookie[] cookies = req.getCookies();
+    private boolean isViewed(Long postId, Long userId) {
+        SetOperations<String, String> setOperations = redisTemplate.opsForSet();
+        String key = userId.toString();
+        String value = postId.toString();
 
-        if (cookies == null) {
-            return false;
+        Set<String> viewedPosts = setOperations.members(key);
+
+        if (viewedPosts.contains(value)) {
+            return true;
         }
 
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().contains(cookieName)) {
-                return true;
-            }
-        }
-
-        Cookie cookie = new Cookie(cookieName, cookieValue);
-        cookie.setPath("/");
-        cookie.setMaxAge(60);
-        res.addCookie(cookie);
+        setOperations.add(key, value);
 
         return false;
     }
+
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/post/view/PostController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/view/PostController.java
@@ -1,10 +1,12 @@
 package com.devcourse.be04daangnmarket.post.view;
 
+import com.devcourse.be04daangnmarket.common.auth.User;
 import com.devcourse.be04daangnmarket.post.application.PostService;
 import com.devcourse.be04daangnmarket.post.domain.constant.Category;
 import com.devcourse.be04daangnmarket.post.domain.constant.TransactionType;
 import com.devcourse.be04daangnmarket.post.dto.PostDto;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,8 +44,10 @@ public class PostController {
     }
 
     @GetMapping(value = "/posts/update/{id}")
-    public String updatePost(@PathVariable Long id, Model model, HttpServletRequest req, HttpServletResponse res) {
-        PostDto.Response post = postService.getPost(id, req, res);
+    public String updatePost(@PathVariable Long id,
+                             @AuthenticationPrincipal User user,
+                             Model model) {
+        PostDto.Response post = postService.getPost(id, user.getId());
 
         model.addAttribute("post", post);
         model.addAttribute("categories", Category.values());

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,14 @@ spring:
       max-file-size: 10MB
       max-request-size: 15MB
 
+  cache:
+    type: redis
+    redis:
+      time-to-live: 3600
+      cache-null-values: true
+      host: localhost
+      port: 6379
+
 jasypt:
   encryptor:
     bean: jasyptStringEncryptor

--- a/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
@@ -75,7 +75,6 @@ class PostRestControllerTest {
 		SecurityContextHolder.getContext().setAuthentication(
 			new UsernamePasswordAuthenticationToken(
 				new User(new Member(
-					"username",
 					"phone",
 					"email",
 					"1234")),
@@ -140,6 +139,7 @@ class PostRestControllerTest {
 	public void getPostTest() throws Exception {
 		// given
 		Long postId = 1L;
+		Long memberId = 1L;
 		PostDto.Response mockResponse = new PostDto.Response(
 			1L,
 			1L,
@@ -156,16 +156,12 @@ class PostRestControllerTest {
 			LocalDateTime.now()
 		);
 
-		MockHttpServletRequest req = new MockHttpServletRequest();
-		MockHttpServletResponse res = new MockHttpServletResponse();
-		when(postService.getPost(1L, req, res)).thenReturn(mockResponse);
+		when(postService.getPost(1L, 1L)).thenReturn(mockResponse);
 
 		// when then
 		mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/posts/" + postId)
 				.contentType(MediaType.APPLICATION_JSON)
-				.accept(MediaType.APPLICATION_JSON)
-				.requestAttr("req", new MockHttpServletRequest()) // HttpServletRequest 모의 객체 추가
-				.requestAttr("res", new MockHttpServletResponse()))
+				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk());
 	}
 

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -104,6 +104,7 @@ class PostServiceTest {
     void getPostTest() {
         // given
         Long postId = 1L;
+        Long memberId =1L;
 
         Post post = new Post(
                 1L,
@@ -116,9 +117,7 @@ class PostServiceTest {
         when(postRepository.findById(postId)).thenReturn(Optional.of(post));
 
         // when
-        MockHttpServletRequest req = new MockHttpServletRequest();
-        MockHttpServletResponse res = new MockHttpServletResponse();
-        PostDto.Response response = postService.getPost(postId, req, res);
+        PostDto.Response response = postService.getPost(postId, memberId);
 
         // then
         assertEquals(post.getId(), response.id());
@@ -130,6 +129,7 @@ class PostServiceTest {
     void viewUpdateSuccessTest() {
         // given
         Long postId = 1L;
+        Long memberId =1L;
 
         Post post = new Post(
                 1L,
@@ -142,9 +142,7 @@ class PostServiceTest {
         when(postRepository.findById(postId)).thenReturn(Optional.of(post));
 
         // when
-        MockHttpServletRequest req = new MockHttpServletRequest();
-        MockHttpServletResponse res = new MockHttpServletResponse();
-        PostDto.Response response = postService.getPost(postId, req, res);
+        PostDto.Response response = postService.getPost(postId, memberId);
 
         // then
         assertEquals(1, response.views());
@@ -156,6 +154,7 @@ class PostServiceTest {
     void viewUpdateFailTest() {
         // given
         Long postId = 1L;
+        Long memberId =1L;
 
         Post post = new Post(
                 1L,
@@ -168,10 +167,7 @@ class PostServiceTest {
         when(postRepository.findById(postId)).thenReturn(Optional.of(post));
 
         // when
-        MockHttpServletRequest req = new MockHttpServletRequest();
-        MockHttpServletResponse res = new MockHttpServletResponse();
-        req.setCookies(new Cookie(postId.toString(), postId.toString()));
-        PostDto.Response response = postService.getPost(postId, req, res);
+        PostDto.Response response = postService.getPost(postId, memberId);
 
         // then
         assertEquals(0, response.views());


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 기존 쿠기를 사용해 구현한 조회수 중복방지 기능을 Redis를 사용하도록 변경했습니다.
- 테스트 결과 쿠키 저장 크기 제한으로 일정 갯수의 게시물을 보면 중복방지 기능이 적용되지 않았습니다

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] Redis 의존성 추가  
- [x] Redis 사용을 위한 도커 컴포즈, 쉘 스크립트, 스프링부트 설정파일 수정   
- [x] Redis DB를 사용해 조회수 중복 방지 기능을 구현

### 🐰 PR POINT  <!-- PR에서 중점적으로 봐야할 부문을 작성해주세요. -->
- 기존 mysql을 사용할때 redis도 같이 사용되도록 인프라 파일을 구성했습니다
- 쿠기를 사용한 코드를 지우고 User.getID() 를 통해사용자 ID를 키 값으로 사용하도록 헀습니다
- 조회수는 로그인 한 회원한정으로 증가하도록 했습니다

### 🥕 리뷰어에게 하고싶은 말  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
