### PR TITLE
[KIM-239] IO작업 롤백 처리

### DIFF
--- a/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/comment/api/CommentRestController.java
@@ -7,27 +7,24 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import com.devcourse.be04daangnmarket.common.image.LocalImageUpload;
-import com.devcourse.be04daangnmarket.common.image.ImageUpload;
-import com.devcourse.be04daangnmarket.common.image.dto.ImageDto;
+import com.devcourse.be04daangnmarket.common.image.LocalImageIOService;
+import com.devcourse.be04daangnmarket.common.image.ImageIOService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @Tag(name = "comment", description = "댓글 API")
 @RestController
 @RequestMapping("/api/v1/comments")
 public class CommentRestController {
     private final CommentService commentService;
-    private final ImageUpload imageUpload;
+    private final ImageIOService imageIOService;
 
-    public CommentRestController(CommentService commentService, LocalImageUpload uploadImageService) {
+    public CommentRestController(CommentService commentService, LocalImageIOService uploadImageService) {
         this.commentService = commentService;
-        this.imageUpload = uploadImageService;
+        this.imageIOService = uploadImageService;
     }
 
     @Tag(name = "comment")
@@ -38,12 +35,11 @@ public class CommentRestController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommentDto.CommentResponse> create(@Valid CommentDto.CreateCommentRequest request,
                                                              @AuthenticationPrincipal User user) {
-        List<ImageDto.ImageDetail> imageDetails = imageUpload.uploadImages(request.files());
         CommentDto.CommentResponse response = commentService.create(request.postId(),
                 user.getId(),
                 user.getUsername(),
                 request.content(),
-                imageDetails);
+                request.files());
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
@@ -58,13 +54,12 @@ public class CommentRestController {
     @PostMapping(value = "/reply", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommentDto.CommentResponse> createReply(@Valid CommentDto.CreateReplyCommentRequest request,
                                                                   @AuthenticationPrincipal User user) {
-        List<ImageDto.ImageDetail> imageDetails = imageUpload.uploadImages(request.files());
         CommentDto.CommentResponse response = commentService.createReply(request.postId(),
                 user.getId(),
                 user.getUsername(),
                 request.commentGroup(),
                 request.content(),
-                imageDetails);
+                request.files());
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
@@ -104,12 +99,11 @@ public class CommentRestController {
     public ResponseEntity<CommentDto.CommentResponse> update(@PathVariable Long id,
                                                              @Valid CommentDto.UpdateCommentRequest request,
                                                              @AuthenticationPrincipal User user) {
-        List<ImageDto.ImageDetail> imageDetails = imageUpload.uploadImages(request.files());
         CommentDto.CommentResponse response = commentService.update(id,
                 request.postId(),
                 user.getUsername(),
                 request.content(),
-                imageDetails);
+                request.files());
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/devcourse/be04daangnmarket/common/config/DataSourceConfig.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/config/DataSourceConfig.java
@@ -11,7 +11,6 @@ import javax.sql.DataSource;
 
 @Configuration
 public class DataSourceConfig {
-
     @Bean
     @Primary
     public DataSource lazyDataSource(DataSourceProperties properties) {
@@ -20,7 +19,7 @@ public class DataSourceConfig {
         dataSource.setUsername(properties.getUsername());
         dataSource.setPassword(properties.getPassword());
         dataSource.setDriverClassName(properties.getDriverClassName());
+
         return new LazyConnectionDataSourceProxy(dataSource);
     }
-
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/common/config/DataSourceConfig.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/config/DataSourceConfig.java
@@ -1,0 +1,26 @@
+package com.devcourse.be04daangnmarket.common.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class DataSourceConfig {
+
+    @Bean
+    @Primary
+    public DataSource lazyDataSource(DataSourceProperties properties) {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(properties.getUrl());
+        dataSource.setUsername(properties.getUsername());
+        dataSource.setPassword(properties.getPassword());
+        dataSource.setDriverClassName(properties.getDriverClassName());
+        return new LazyConnectionDataSourceProxy(dataSource);
+    }
+
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/common/config/EventConfiguration.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/config/EventConfiguration.java
@@ -1,0 +1,21 @@
+package com.devcourse.be04daangnmarket.common.config;
+
+import com.devcourse.be04daangnmarket.common.image.ImageEvents;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EventConfiguration {
+    private final ApplicationContext applicationContext;
+
+    public EventConfiguration(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Bean
+    public InitializingBean eventsInitializer() {
+        return () -> ImageEvents.setPublisher(applicationContext);
+    }
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/common/image/ImageEvents.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/image/ImageEvents.java
@@ -1,0 +1,17 @@
+package com.devcourse.be04daangnmarket.common.image;
+
+import org.springframework.context.ApplicationEventPublisher;
+
+public class ImageEvents {
+    private static ApplicationEventPublisher publisher;
+
+    public static void setPublisher(ApplicationEventPublisher publisher) {
+        ImageEvents.publisher = publisher;
+    }
+
+    public static void raise(Object event) {
+        if (publisher != null) {
+            publisher.publishEvent(event);
+        }
+    }
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/common/image/ImageIOService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/image/ImageIOService.java
@@ -5,6 +5,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-public interface ImageUpload {
+public interface ImageIOService {
     List<ImageDto.ImageDetail> uploadImages(List<MultipartFile> multipartFiles);
+
+    void delete(String path);
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/common/image/ImageSavedEventHandler.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/image/ImageSavedEventHandler.java
@@ -1,0 +1,25 @@
+package com.devcourse.be04daangnmarket.common.image;
+
+import com.devcourse.be04daangnmarket.common.image.dto.ImageSavedEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Service
+public class ImageSavedEventHandler {
+    private final ImageIOService imageIOService;
+
+    public ImageSavedEventHandler(ImageIOService imageIOService) {
+        this.imageIOService = imageIOService;
+    }
+
+    @Async
+    @TransactionalEventListener(
+            classes = ImageSavedEvent.class,
+            phase = TransactionPhase.AFTER_ROLLBACK
+    )
+    public void deleteHandle(ImageSavedEvent event) {
+        imageIOService.delete(event.getFileName());
+    }
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/common/image/LocalImageIOService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/image/LocalImageIOService.java
@@ -2,6 +2,7 @@ package com.devcourse.be04daangnmarket.common.image;
 
 import com.devcourse.be04daangnmarket.common.image.dto.Type;
 import com.devcourse.be04daangnmarket.common.image.dto.ImageDto;
+import com.devcourse.be04daangnmarket.image.exception.FileDeleteException;
 import com.devcourse.be04daangnmarket.image.exception.FileUploadException;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,14 +11,18 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static com.devcourse.be04daangnmarket.image.exception.ExceptionMessage.FILE_DELETE_EXCEPTION;
 import static com.devcourse.be04daangnmarket.image.exception.ExceptionMessage.FILE_UPLOAD_EXCEPTION;
 
 @Component
-public class LocalImageUpload implements ImageUpload {
+public class LocalImageIOService implements ImageIOService {
     @Value("${custom.base-path.image}")
    	private String FOLDER_PATH;
 
@@ -73,4 +78,15 @@ public class LocalImageUpload implements ImageUpload {
     private String getFullPath(String uniqueName) {
    		return FOLDER_PATH + "/" + uniqueName;
    	}
+
+	@Override
+	public void delete(String path) {
+		Path fullPath = Paths.get(FOLDER_PATH + path);
+
+		try {
+			Files.delete(fullPath);
+		} catch (IOException e) {
+			throw new FileDeleteException(FILE_DELETE_EXCEPTION.getMessage());
+		}
+	}
 }

--- a/src/main/java/com/devcourse/be04daangnmarket/common/image/LocalImageIOService.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/image/LocalImageIOService.java
@@ -1,5 +1,6 @@
 package com.devcourse.be04daangnmarket.common.image;
 
+import com.devcourse.be04daangnmarket.common.image.dto.ImageSavedEvent;
 import com.devcourse.be04daangnmarket.common.image.dto.Type;
 import com.devcourse.be04daangnmarket.common.image.dto.ImageDto;
 import com.devcourse.be04daangnmarket.image.exception.FileDeleteException;
@@ -37,11 +38,17 @@ public class LocalImageIOService implements ImageIOService {
 
 	@Override
     public List<ImageDto.ImageDetail> uploadImages(List<MultipartFile> multipartFiles) {
-		return isEmptyImages(multipartFiles)
+		List<ImageDto.ImageDetail> imageDetails = isEmptyImages(multipartFiles)
 				? Collections.emptyList()
 				: multipartFiles.stream()
-								.map(this::uploadImage)
-								.toList();
+				.map(this::uploadImage)
+				.toList();
+
+		for (ImageDto.ImageDetail imageDetail : imageDetails) {
+			ImageEvents.raise(new ImageSavedEvent(imageDetail.uniqueName()));
+		}
+
+		return imageDetails;
     }
 
 	private boolean isEmptyImages(List<MultipartFile> multipartFiles) {
@@ -80,8 +87,8 @@ public class LocalImageIOService implements ImageIOService {
    	}
 
 	@Override
-	public void delete(String path) {
-		Path fullPath = Paths.get(FOLDER_PATH + path);
+	public void delete(String fileName) {
+		Path fullPath = Paths.get(FOLDER_PATH + "/" + fileName);
 
 		try {
 			Files.delete(fullPath);

--- a/src/main/java/com/devcourse/be04daangnmarket/common/image/dto/ImageSavedEvent.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/common/image/dto/ImageSavedEvent.java
@@ -1,0 +1,13 @@
+package com.devcourse.be04daangnmarket.common.image.dto;
+
+public class ImageSavedEvent {
+    private String fileName;
+
+    public ImageSavedEvent(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
+++ b/src/main/java/com/devcourse/be04daangnmarket/post/api/PostRestController.java
@@ -3,7 +3,7 @@ package com.devcourse.be04daangnmarket.post.api;
 import com.devcourse.be04daangnmarket.comment.application.CommentProviderService;
 import com.devcourse.be04daangnmarket.comment.dto.CommentDto;
 import com.devcourse.be04daangnmarket.common.auth.User;
-import com.devcourse.be04daangnmarket.common.image.ImageUpload;
+import com.devcourse.be04daangnmarket.common.image.ImageIOService;
 import com.devcourse.be04daangnmarket.common.image.dto.ImageDto;
 import com.devcourse.be04daangnmarket.member.dto.ProfileDto;
 
@@ -14,8 +14,6 @@ import com.devcourse.be04daangnmarket.post.dto.PostDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -38,12 +36,12 @@ public class PostRestController {
 
     private final PostService postService;
     private final CommentProviderService commentService;
-    private final ImageUpload imageUpload;
+    private final ImageIOService imageIOService;
 
-    public PostRestController(PostService postService, CommentProviderService commentService, ImageUpload imageUpload) {
+    public PostRestController(PostService postService, CommentProviderService commentService, ImageIOService imageIOService) {
         this.postService = postService;
         this.commentService = commentService;
-        this.imageUpload = imageUpload;
+        this.imageIOService = imageIOService;
     }
 
     @Tag(name = "post")
@@ -54,7 +52,7 @@ public class PostRestController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<PostDto.Response> createPost(@Valid PostDto.CreateRequest request,
                                                        @AuthenticationPrincipal User user) throws IOException {
-        List<ImageDto.ImageDetail> imageDetails = imageUpload.uploadImages(request.files());
+        List<ImageDto.ImageDetail> imageDetails = imageIOService.uploadImages(request.files());
 
         PostDto.Response response = postService.create(
                 user.getId(),
@@ -154,7 +152,7 @@ public class PostRestController {
     @PutMapping(path = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<PostDto.Response> updatePost(@PathVariable @NotNull Long id,
                                                        @Valid PostDto.UpdateRequest request) {
-        List<ImageDto.ImageDetail> imageDetails = imageUpload.uploadImages(request.files());
+        List<ImageDto.ImageDetail> imageDetails = imageIOService.uploadImages(request.files());
         PostDto.Response response = postService.update(
                 id,
                 request.title(),

--- a/src/test/java/com/devcourse/be04daangnmarket/comment/api/CommentRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/comment/api/CommentRestControllerTest.java
@@ -1,9 +1,8 @@
 package com.devcourse.be04daangnmarket.comment.api;
 
-import com.devcourse.be04daangnmarket.comment.domain.Comment;
 import com.devcourse.be04daangnmarket.comment.dto.CommentDto;
 import com.devcourse.be04daangnmarket.common.auth.User;
-import com.devcourse.be04daangnmarket.common.image.LocalImageUpload;
+import com.devcourse.be04daangnmarket.common.image.LocalImageIOService;
 import com.devcourse.be04daangnmarket.common.jwt.JwtTokenProvider;
 import com.devcourse.be04daangnmarket.image.application.ImageService;
 import com.devcourse.be04daangnmarket.common.image.dto.ImageDto;
@@ -31,7 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
@@ -63,7 +61,7 @@ class CommentRestControllerTest {
     private JwtTokenProvider jwtTokenProvider;
 
     @MockBean
-    private LocalImageUpload imageUpload;
+    private LocalImageIOService imageUpload;
 
     private Member member;
     private Post post;
@@ -102,7 +100,7 @@ class CommentRestControllerTest {
                 1L,
                 "username",
                 "댓글",
-                imageDetails
+                multipartFiles
         )).willReturn(mockResponse);
 
         //when & then
@@ -136,7 +134,7 @@ class CommentRestControllerTest {
                 eq("username"),
                 eq(1),
                 eq("댓글"),
-                eq(imageDetails)
+                eq(imagePaths)
         )).willReturn(mockResponse);
 
         //when & then

--- a/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/api/PostRestControllerTest.java
@@ -4,7 +4,8 @@ import com.devcourse.be04daangnmarket.comment.application.CommentService;
 import com.devcourse.be04daangnmarket.comment.dto.CommentDto;
 import com.devcourse.be04daangnmarket.common.auth.User;
 import com.devcourse.be04daangnmarket.common.config.SecurityConfig;
-import com.devcourse.be04daangnmarket.common.image.LocalImageUpload;
+import com.devcourse.be04daangnmarket.common.image.ImageIOService;
+import com.devcourse.be04daangnmarket.common.image.LocalImageIOService;
 import com.devcourse.be04daangnmarket.common.jwt.JwtTokenProvider;
 import com.devcourse.be04daangnmarket.member.domain.Member;
 import com.devcourse.be04daangnmarket.post.application.PostService;
@@ -64,7 +65,7 @@ class PostRestControllerTest {
     private CommentService commentService;
 
     @MockBean
-    private LocalImageUpload imageUpload;
+    private ImageIOService imageUpload;
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
+++ b/src/test/java/com/devcourse/be04daangnmarket/post/application/PostServiceTest.java
@@ -1,6 +1,6 @@
 package com.devcourse.be04daangnmarket.post.application;
 
-import com.devcourse.be04daangnmarket.common.image.LocalImageUpload;
+import com.devcourse.be04daangnmarket.common.image.LocalImageIOService;
 import com.devcourse.be04daangnmarket.common.image.dto.ImageDto;
 import com.devcourse.be04daangnmarket.common.image.dto.Type;
 import com.devcourse.be04daangnmarket.common.jwt.JwtTokenProvider;
@@ -51,7 +51,7 @@ class PostServiceTest {
     private ProfileService profileService;
 
     @Mock
-    private LocalImageUpload imageUpload;
+    private LocalImageIOService imageUpload;
 
     @Mock
     RedisTemplate<String, String> redisTemplate;


### PR DESCRIPTION
<!--
  규현팀 당근마켓 클론코딩 프로젝트를 위한 PR 템플릿
-->

### 🐰 PR 설명 <!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
발단 : 만약 이미지를 저장했는데 DB작업에서 에러가 발생해서 로컬에 저장된 이미지는 어떻게 롤백을 할 수 있을까?를 해결하는 PR입니다.
LazyConnectionDataSourceProxy을 설정해주어 쿼리가 발생하는 시점에 DB 커넥션을 가져와 불필요한 DB 커넥션 점유를 제거하였습니다.
그리고 보상 트랜잭션을 적용하여 하나의 트랜잭션에서 에러가 발생한 경우 로컬 이미지 저장소에 이미지를 삭제하도록 적용하였습니다.

### 🥕 작업단위  <!-- PR내 작업단위를 작성해주세요. 커밋처럼 구체적으로 설명해주세요. -->
- [x] 로컬 이미지 삭제 로직을 구현하다
- [x] LazyConnectionDataSourceProxy를 통해 쿼리가 발생하면 DB커넥션을 점유하도록 설정하다
- [x] 보상 트랜잭션을 적용하다
- [x] IO작업을 하나의 트랜잭션에서 작업하도록 수정하다
